### PR TITLE
add relocatable cmake generated config-file package installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vscode
 build
+*~
+_*

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ install:
   - sudo make install
   - cd ../..
   - mkdir -p build && cd build
-  - cmake .. -DUNITTEST=ON
+  - cmake .. -DFDEEP_BUILD_UNITTEST=ON
 
 script:
   - which $CXX

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,13 @@ install:
   - sudo make install
   - sudo ln -s /usr/local/include/eigen3/Eigen /usr/local/include/Eigen
   - cd ../..
+  - git clone https://github.com/onqtam/doctest
+  - cd doctest
+  - mkdir -p build && cd build
+  - cmake ..
+  - make
+  - sudo make install
+  - cd ../..
   - git clone https://github.com/nlohmann/json
   - cd json
   - mkdir -p build && cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,38 +1,51 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.2)
 
-project(frugally-deep)
-set(PROJECT_VERSION 0.2)
+set(FDEEP_TOP_DIR ${CMAKE_CURRENT_LIST_DIR})
+
+list(APPEND CMAKE_MODULE_PATH "${FDEEP_TOP_DIR}/cmake")
+
+include(cmake/hunter.cmake) # default off
+
+project(frugally-deep VERSION 0.2)
 
 message(STATUS "===( ${PROJECT_NAME} ${PROJECT_VERSION} )===")
 
-option(UNITTEST "Build unit tests" OFF)
+option(FDEEP_BUILD_UNITTEST "Build unit tests" OFF)
+option(FDEEP_USE_TOOLCHAIN "Use external toolchain" OFF)
+option(FDEEP_USE_DOUBLE "Use doulbe precision" OFF)
 
-install(DIRECTORY include/fdeep DESTINATION include)
+if(NOT FDEEP_USE_TOOLCHAIN)
+  include(cmake/toolchain.cmake)
+endif()
 
-add_compile_options(-Wall
-                    -Wextra
-                    -pedantic
-                    -Werror
-                    -Weffc++
-                    -Wconversion
-                    -Wsign-conversion
-                    -Wctor-dtor-privacy
-                    -Wreorder
-                    -Wold-style-cast
-                    -Wparentheses
-                    )
+add_library(fdeep INTERFACE)
+target_include_directories(fdeep INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+  )
+
+if(FDEEP_USE_DOUBLE)
+  target_compile_definitions(fdeep INTERFACE FDEEP_FLOAT_TYPE=double)
+endif()
 
 find_package(Threads REQUIRED)
+target_link_libraries(fdeep INTERFACE Threads::Threads)
 
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+hunter_add_package(FunctionalPlus) # default noop
+find_package(FunctionalPlus CONFIG REQUIRED)
+target_link_libraries(fdeep INTERFACE FunctionalPlus::fplus)
 
-include_directories(include)
+hunter_add_package(Eigen) # default noop
+find_package(Eigen3 CONFIG REQUIRED)
+target_link_libraries(fdeep INTERFACE Eigen3::Eigen)
 
-if( UNITTEST )
+hunter_add_package(nlohmann_json) # default noop
+find_package(nlohmann_json CONFIG REQUIRED)
+target_link_libraries(fdeep INTERFACE nlohmann_json)
+
+if(FDEEP_BUILD_UNITTEST)
     enable_testing()
     subdirs(test)
 endif()
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+# pkgconfig installation:
+include(cmake/pkgconfig.cmake)

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ cd ../..
 Building the tests (optional) requires [doctest](https://github.com/onqtam/doctest). Unit Tests are disabled by default – they are enabled and executed by:
 
 ```
-cmake -DUNITTEST=ON ..
+cmake -DFDEEP_UNITTEST=ON ..
 make unittest
 ```
 

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,9 @@
+@PACKAGE_INIT@
+
+find_package(Eigen3 CONFIG REQUIRED)
+find_package(FunctionalPlus CONFIG REQUIRED)
+find_package(Threads REQUIRED) 
+find_package(nlohmann_json CONFIG REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/cmake/HunterGate.cmake
+++ b/cmake/HunterGate.cmake
@@ -1,0 +1,543 @@
+# Copyright (c) 2013-2017, Ruslan Baratov
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This is a gate file to Hunter package manager.
+# Include this file using `include` command and add package you need, example:
+#
+#     cmake_minimum_required(VERSION 3.0)
+#
+#     include("cmake/HunterGate.cmake")
+#     HunterGate(
+#         URL "https://github.com/path/to/hunter/archive.tar.gz"
+#         SHA1 "798501e983f14b28b10cda16afa4de69eee1da1d"
+#     )
+#
+#     project(MyProject)
+#
+#     hunter_add_package(Foo)
+#     hunter_add_package(Boo COMPONENTS Bar Baz)
+#
+# Projects:
+#     * https://github.com/hunter-packages/gate/
+#     * https://github.com/ruslo/hunter
+
+option(HUNTER_ENABLED "Enable Hunter package manager support" ON)
+if(HUNTER_ENABLED)
+  if(CMAKE_VERSION VERSION_LESS "3.0")
+    message(FATAL_ERROR "At least CMake version 3.0 required for hunter dependency management."
+      " Update CMake or set HUNTER_ENABLED to OFF.")
+  endif()
+endif()
+
+include(CMakeParseArguments) # cmake_parse_arguments
+
+option(HUNTER_STATUS_PRINT "Print working status" ON)
+option(HUNTER_STATUS_DEBUG "Print a lot info" OFF)
+option(HUNTER_TLS_VERIFY "Enable/disable TLS certificate checking on downloads" ON)
+
+set(HUNTER_WIKI "https://github.com/ruslo/hunter/wiki")
+
+function(hunter_gate_status_print)
+  foreach(print_message ${ARGV})
+    if(HUNTER_STATUS_PRINT OR HUNTER_STATUS_DEBUG)
+      message(STATUS "[hunter] ${print_message}")
+    endif()
+  endforeach()
+endfunction()
+
+function(hunter_gate_status_debug)
+  foreach(print_message ${ARGV})
+    if(HUNTER_STATUS_DEBUG)
+      string(TIMESTAMP timestamp)
+      message(STATUS "[hunter *** DEBUG *** ${timestamp}] ${print_message}")
+    endif()
+  endforeach()
+endfunction()
+
+function(hunter_gate_wiki wiki_page)
+  message("------------------------------ WIKI -------------------------------")
+  message("    ${HUNTER_WIKI}/${wiki_page}")
+  message("-------------------------------------------------------------------")
+  message("")
+  message(FATAL_ERROR "")
+endfunction()
+
+function(hunter_gate_internal_error)
+  message("")
+  foreach(print_message ${ARGV})
+    message("[hunter ** INTERNAL **] ${print_message}")
+  endforeach()
+  message("[hunter ** INTERNAL **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
+  message("")
+  hunter_gate_wiki("error.internal")
+endfunction()
+
+function(hunter_gate_fatal_error)
+  cmake_parse_arguments(hunter "" "WIKI" "" "${ARGV}")
+  string(COMPARE EQUAL "${hunter_WIKI}" "" have_no_wiki)
+  if(have_no_wiki)
+    hunter_gate_internal_error("Expected wiki")
+  endif()
+  message("")
+  foreach(x ${hunter_UNPARSED_ARGUMENTS})
+    message("[hunter ** FATAL ERROR **] ${x}")
+  endforeach()
+  message("[hunter ** FATAL ERROR **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
+  message("")
+  hunter_gate_wiki("${hunter_WIKI}")
+endfunction()
+
+function(hunter_gate_user_error)
+  hunter_gate_fatal_error(${ARGV} WIKI "error.incorrect.input.data")
+endfunction()
+
+function(hunter_gate_self root version sha1 result)
+  string(COMPARE EQUAL "${root}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("root is empty")
+  endif()
+
+  string(COMPARE EQUAL "${version}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("version is empty")
+  endif()
+
+  string(COMPARE EQUAL "${sha1}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("sha1 is empty")
+  endif()
+
+  string(SUBSTRING "${sha1}" 0 7 archive_id)
+
+  if(EXISTS "${root}/cmake/Hunter")
+    set(hunter_self "${root}")
+  else()
+    set(
+        hunter_self
+        "${root}/_Base/Download/Hunter/${version}/${archive_id}/Unpacked"
+    )
+  endif()
+
+  set("${result}" "${hunter_self}" PARENT_SCOPE)
+endfunction()
+
+# Set HUNTER_GATE_ROOT cmake variable to suitable value.
+function(hunter_gate_detect_root)
+  # Check CMake variable
+  string(COMPARE NOTEQUAL "${HUNTER_ROOT}" "" not_empty)
+  if(not_empty)
+    set(HUNTER_GATE_ROOT "${HUNTER_ROOT}" PARENT_SCOPE)
+    hunter_gate_status_debug("HUNTER_ROOT detected by cmake variable")
+    return()
+  endif()
+
+  # Check environment variable
+  string(COMPARE NOTEQUAL "$ENV{HUNTER_ROOT}" "" not_empty)
+  if(not_empty)
+    set(HUNTER_GATE_ROOT "$ENV{HUNTER_ROOT}" PARENT_SCOPE)
+    hunter_gate_status_debug("HUNTER_ROOT detected by environment variable")
+    return()
+  endif()
+
+  # Check HOME environment variable
+  string(COMPARE NOTEQUAL "$ENV{HOME}" "" result)
+  if(result)
+    set(HUNTER_GATE_ROOT "$ENV{HOME}/.hunter" PARENT_SCOPE)
+    hunter_gate_status_debug("HUNTER_ROOT set using HOME environment variable")
+    return()
+  endif()
+
+  # Check SYSTEMDRIVE and USERPROFILE environment variable (windows only)
+  if(WIN32)
+    string(COMPARE NOTEQUAL "$ENV{SYSTEMDRIVE}" "" result)
+    if(result)
+      set(HUNTER_GATE_ROOT "$ENV{SYSTEMDRIVE}/.hunter" PARENT_SCOPE)
+      hunter_gate_status_debug(
+          "HUNTER_ROOT set using SYSTEMDRIVE environment variable"
+      )
+      return()
+    endif()
+
+    string(COMPARE NOTEQUAL "$ENV{USERPROFILE}" "" result)
+    if(result)
+      set(HUNTER_GATE_ROOT "$ENV{USERPROFILE}/.hunter" PARENT_SCOPE)
+      hunter_gate_status_debug(
+          "HUNTER_ROOT set using USERPROFILE environment variable"
+      )
+      return()
+    endif()
+  endif()
+
+  hunter_gate_fatal_error(
+      "Can't detect HUNTER_ROOT"
+      WIKI "error.detect.hunter.root"
+  )
+endfunction()
+
+macro(hunter_gate_lock dir)
+  if(NOT HUNTER_SKIP_LOCK)
+    if("${CMAKE_VERSION}" VERSION_LESS "3.2")
+      hunter_gate_fatal_error(
+          "Can't lock, upgrade to CMake 3.2 or use HUNTER_SKIP_LOCK"
+          WIKI "error.can.not.lock"
+      )
+    endif()
+    hunter_gate_status_debug("Locking directory: ${dir}")
+    file(LOCK "${dir}" DIRECTORY GUARD FUNCTION)
+    hunter_gate_status_debug("Lock done")
+  endif()
+endmacro()
+
+function(hunter_gate_download dir)
+  string(
+      COMPARE
+      NOTEQUAL
+      "$ENV{HUNTER_DISABLE_AUTOINSTALL}"
+      ""
+      disable_autoinstall
+  )
+  if(disable_autoinstall AND NOT HUNTER_RUN_INSTALL)
+    hunter_gate_fatal_error(
+        "Hunter not found in '${dir}'"
+        "Set HUNTER_RUN_INSTALL=ON to auto-install it from '${HUNTER_GATE_URL}'"
+        "Settings:"
+        "  HUNTER_ROOT: ${HUNTER_GATE_ROOT}"
+        "  HUNTER_SHA1: ${HUNTER_GATE_SHA1}"
+        WIKI "error.run.install"
+    )
+  endif()
+  string(COMPARE EQUAL "${dir}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("Empty 'dir' argument")
+  endif()
+
+  string(COMPARE EQUAL "${HUNTER_GATE_SHA1}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("HUNTER_GATE_SHA1 empty")
+  endif()
+
+  string(COMPARE EQUAL "${HUNTER_GATE_URL}" "" is_bad)
+  if(is_bad)
+    hunter_gate_internal_error("HUNTER_GATE_URL empty")
+  endif()
+
+  set(done_location "${dir}/DONE")
+  set(sha1_location "${dir}/SHA1")
+
+  set(build_dir "${dir}/Build")
+  set(cmakelists "${dir}/CMakeLists.txt")
+
+  hunter_gate_lock("${dir}")
+  if(EXISTS "${done_location}")
+    # while waiting for lock other instance can do all the job
+    hunter_gate_status_debug("File '${done_location}' found, skip install")
+    return()
+  endif()
+
+  file(REMOVE_RECURSE "${build_dir}")
+  file(REMOVE_RECURSE "${cmakelists}")
+
+  file(MAKE_DIRECTORY "${build_dir}") # check directory permissions
+
+  # Disabling languages speeds up a little bit, reduces noise in the output
+  # and avoids path too long windows error
+  file(
+      WRITE
+      "${cmakelists}"
+      "cmake_minimum_required(VERSION 3.0)\n"
+      "project(HunterDownload LANGUAGES NONE)\n"
+      "include(ExternalProject)\n"
+      "ExternalProject_Add(\n"
+      "    Hunter\n"
+      "    URL\n"
+      "    \"${HUNTER_GATE_URL}\"\n"
+      "    URL_HASH\n"
+      "    SHA1=${HUNTER_GATE_SHA1}\n"
+      "    DOWNLOAD_DIR\n"
+      "    \"${dir}\"\n"
+      "    TLS_VERIFY\n"
+      "    ${HUNTER_TLS_VERIFY}\n"
+      "    SOURCE_DIR\n"
+      "    \"${dir}/Unpacked\"\n"
+      "    CONFIGURE_COMMAND\n"
+      "    \"\"\n"
+      "    BUILD_COMMAND\n"
+      "    \"\"\n"
+      "    INSTALL_COMMAND\n"
+      "    \"\"\n"
+      ")\n"
+  )
+
+  if(HUNTER_STATUS_DEBUG)
+    set(logging_params "")
+  else()
+    set(logging_params OUTPUT_QUIET)
+  endif()
+
+  hunter_gate_status_debug("Run generate")
+
+  # Need to add toolchain file too.
+  # Otherwise on Visual Studio + MDD this will fail with error:
+  # "Could not find an appropriate version of the Windows 10 SDK installed on this machine"
+  if(EXISTS "${CMAKE_TOOLCHAIN_FILE}")
+    get_filename_component(absolute_CMAKE_TOOLCHAIN_FILE "${CMAKE_TOOLCHAIN_FILE}" ABSOLUTE)
+    set(toolchain_arg "-DCMAKE_TOOLCHAIN_FILE=${absolute_CMAKE_TOOLCHAIN_FILE}")
+  else()
+    # 'toolchain_arg' can't be empty
+    set(toolchain_arg "-DCMAKE_TOOLCHAIN_FILE=")
+  endif()
+
+  string(COMPARE EQUAL "${CMAKE_MAKE_PROGRAM}" "" no_make)
+  if(no_make)
+    set(make_arg "")
+  else()
+    # Test case: remove Ninja from PATH but set it via CMAKE_MAKE_PROGRAM
+    set(make_arg "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}")
+  endif()
+
+  execute_process(
+      COMMAND
+      "${CMAKE_COMMAND}"
+      "-H${dir}"
+      "-B${build_dir}"
+      "-G${CMAKE_GENERATOR}"
+      "${toolchain_arg}"
+      ${make_arg}
+      WORKING_DIRECTORY "${dir}"
+      RESULT_VARIABLE download_result
+      ${logging_params}
+  )
+
+  if(NOT download_result EQUAL 0)
+    hunter_gate_internal_error("Configure project failed")
+  endif()
+
+  hunter_gate_status_print(
+      "Initializing Hunter workspace (${HUNTER_GATE_SHA1})"
+      "  ${HUNTER_GATE_URL}"
+      "  -> ${dir}"
+  )
+  execute_process(
+      COMMAND "${CMAKE_COMMAND}" --build "${build_dir}"
+      WORKING_DIRECTORY "${dir}"
+      RESULT_VARIABLE download_result
+      ${logging_params}
+  )
+
+  if(NOT download_result EQUAL 0)
+    hunter_gate_internal_error("Build project failed")
+  endif()
+
+  file(REMOVE_RECURSE "${build_dir}")
+  file(REMOVE_RECURSE "${cmakelists}")
+
+  file(WRITE "${sha1_location}" "${HUNTER_GATE_SHA1}")
+  file(WRITE "${done_location}" "DONE")
+
+  hunter_gate_status_debug("Finished")
+endfunction()
+
+# Must be a macro so master file 'cmake/Hunter' can
+# apply all variables easily just by 'include' command
+# (otherwise PARENT_SCOPE magic needed)
+macro(HunterGate)
+  if(HUNTER_GATE_DONE)
+    # variable HUNTER_GATE_DONE set explicitly for external project
+    # (see `hunter_download`)
+    set_property(GLOBAL PROPERTY HUNTER_GATE_DONE YES)
+  endif()
+
+  # First HunterGate command will init Hunter, others will be ignored
+  get_property(_hunter_gate_done GLOBAL PROPERTY HUNTER_GATE_DONE SET)
+
+  if(NOT HUNTER_ENABLED)
+    # Empty function to avoid error "unknown function"
+    function(hunter_add_package)
+    endfunction()
+
+    set(
+        _hunter_gate_disabled_mode_dir
+        "${CMAKE_CURRENT_LIST_DIR}/cmake/Hunter/disabled-mode"
+    )
+    if(EXISTS "${_hunter_gate_disabled_mode_dir}")
+      hunter_gate_status_debug(
+          "Adding \"disabled-mode\" modules: ${_hunter_gate_disabled_mode_dir}"
+      )
+      list(APPEND CMAKE_PREFIX_PATH "${_hunter_gate_disabled_mode_dir}")
+    endif()
+  elseif(_hunter_gate_done)
+    hunter_gate_status_debug("Secondary HunterGate (use old settings)")
+    hunter_gate_self(
+        "${HUNTER_CACHED_ROOT}"
+        "${HUNTER_VERSION}"
+        "${HUNTER_SHA1}"
+        _hunter_self
+    )
+    include("${_hunter_self}/cmake/Hunter")
+  else()
+    set(HUNTER_GATE_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
+
+    string(COMPARE NOTEQUAL "${PROJECT_NAME}" "" _have_project_name)
+    if(_have_project_name)
+      hunter_gate_fatal_error(
+          "Please set HunterGate *before* 'project' command. "
+          "Detected project: ${PROJECT_NAME}"
+          WIKI "error.huntergate.before.project"
+      )
+    endif()
+
+    cmake_parse_arguments(
+        HUNTER_GATE "LOCAL" "URL;SHA1;GLOBAL;FILEPATH" "" ${ARGV}
+    )
+
+    string(COMPARE EQUAL "${HUNTER_GATE_SHA1}" "" _empty_sha1)
+    string(COMPARE EQUAL "${HUNTER_GATE_URL}" "" _empty_url)
+    string(
+        COMPARE
+        NOTEQUAL
+        "${HUNTER_GATE_UNPARSED_ARGUMENTS}"
+        ""
+        _have_unparsed
+    )
+    string(COMPARE NOTEQUAL "${HUNTER_GATE_GLOBAL}" "" _have_global)
+    string(COMPARE NOTEQUAL "${HUNTER_GATE_FILEPATH}" "" _have_filepath)
+
+    if(_have_unparsed)
+      hunter_gate_user_error(
+          "HunterGate unparsed arguments: ${HUNTER_GATE_UNPARSED_ARGUMENTS}"
+      )
+    endif()
+    if(_empty_sha1)
+      hunter_gate_user_error("SHA1 suboption of HunterGate is mandatory")
+    endif()
+    if(_empty_url)
+      hunter_gate_user_error("URL suboption of HunterGate is mandatory")
+    endif()
+    if(_have_global)
+      if(HUNTER_GATE_LOCAL)
+        hunter_gate_user_error("Unexpected LOCAL (already has GLOBAL)")
+      endif()
+      if(_have_filepath)
+        hunter_gate_user_error("Unexpected FILEPATH (already has GLOBAL)")
+      endif()
+    endif()
+    if(HUNTER_GATE_LOCAL)
+      if(_have_global)
+        hunter_gate_user_error("Unexpected GLOBAL (already has LOCAL)")
+      endif()
+      if(_have_filepath)
+        hunter_gate_user_error("Unexpected FILEPATH (already has LOCAL)")
+      endif()
+    endif()
+    if(_have_filepath)
+      if(_have_global)
+        hunter_gate_user_error("Unexpected GLOBAL (already has FILEPATH)")
+      endif()
+      if(HUNTER_GATE_LOCAL)
+        hunter_gate_user_error("Unexpected LOCAL (already has FILEPATH)")
+      endif()
+    endif()
+
+    hunter_gate_detect_root() # set HUNTER_GATE_ROOT
+
+    # Beautify path, fix probable problems with windows path slashes
+    get_filename_component(
+        HUNTER_GATE_ROOT "${HUNTER_GATE_ROOT}" ABSOLUTE
+    )
+    hunter_gate_status_debug("HUNTER_ROOT: ${HUNTER_GATE_ROOT}")
+    if(NOT HUNTER_ALLOW_SPACES_IN_PATH)
+      string(FIND "${HUNTER_GATE_ROOT}" " " _contain_spaces)
+      if(NOT _contain_spaces EQUAL -1)
+        hunter_gate_fatal_error(
+            "HUNTER_ROOT (${HUNTER_GATE_ROOT}) contains spaces."
+            "Set HUNTER_ALLOW_SPACES_IN_PATH=ON to skip this error"
+            "(Use at your own risk!)"
+            WIKI "error.spaces.in.hunter.root"
+        )
+      endif()
+    endif()
+
+    string(
+        REGEX
+        MATCH
+        "[0-9]+\\.[0-9]+\\.[0-9]+[-_a-z0-9]*"
+        HUNTER_GATE_VERSION
+        "${HUNTER_GATE_URL}"
+    )
+    string(COMPARE EQUAL "${HUNTER_GATE_VERSION}" "" _is_empty)
+    if(_is_empty)
+      set(HUNTER_GATE_VERSION "unknown")
+    endif()
+
+    hunter_gate_self(
+        "${HUNTER_GATE_ROOT}"
+        "${HUNTER_GATE_VERSION}"
+        "${HUNTER_GATE_SHA1}"
+        _hunter_self
+    )
+
+    set(_master_location "${_hunter_self}/cmake/Hunter")
+    if(EXISTS "${HUNTER_GATE_ROOT}/cmake/Hunter")
+      # Hunter downloaded manually (e.g. by 'git clone')
+      set(_unused "xxxxxxxxxx")
+      set(HUNTER_GATE_SHA1 "${_unused}")
+      set(HUNTER_GATE_VERSION "${_unused}")
+    else()
+      get_filename_component(_archive_id_location "${_hunter_self}/.." ABSOLUTE)
+      set(_done_location "${_archive_id_location}/DONE")
+      set(_sha1_location "${_archive_id_location}/SHA1")
+
+      # Check Hunter already downloaded by HunterGate
+      if(NOT EXISTS "${_done_location}")
+        hunter_gate_download("${_archive_id_location}")
+      endif()
+
+      if(NOT EXISTS "${_done_location}")
+        hunter_gate_internal_error("hunter_gate_download failed")
+      endif()
+
+      if(NOT EXISTS "${_sha1_location}")
+        hunter_gate_internal_error("${_sha1_location} not found")
+      endif()
+      file(READ "${_sha1_location}" _sha1_value)
+      string(COMPARE EQUAL "${_sha1_value}" "${HUNTER_GATE_SHA1}" _is_equal)
+      if(NOT _is_equal)
+        hunter_gate_internal_error(
+            "Short SHA1 collision:"
+            "  ${_sha1_value} (from ${_sha1_location})"
+            "  ${HUNTER_GATE_SHA1} (HunterGate)"
+        )
+      endif()
+      if(NOT EXISTS "${_master_location}")
+        hunter_gate_user_error(
+            "Master file not found:"
+            "  ${_master_location}"
+            "try to update Hunter/HunterGate"
+        )
+      endif()
+    endif()
+    include("${_master_location}")
+    set_property(GLOBAL PROPERTY HUNTER_GATE_DONE YES)
+  endif()
+endmacro()

--- a/cmake/hunter.cmake
+++ b/cmake/hunter.cmake
@@ -1,0 +1,6 @@
+option(HUNTER_ENABLED "Enable Hunter package manager support" OFF)
+include("cmake/HunterGate.cmake")
+HunterGate(
+    URL "https://github.com/ruslo/hunter/archive/v0.20.0.tar.gz"
+    SHA1 "e94556ed41e5432997450bca7232db72a3b0d5ef"    
+)

--- a/cmake/pkgconfig.cmake
+++ b/cmake/pkgconfig.cmake
@@ -1,0 +1,73 @@
+# Installation (https://github.com/forexample/package-example) {
+
+# Layout. This works for all platforms:
+#   * <prefix>/lib/cmake/<PROJECT-NAME>
+#   * <prefix>/lib/
+#   * <prefix>/include/
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(include_install_dir "include")
+
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+# Include module with fuction 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+# Use:
+#   * PROJECT_VERSION
+write_basic_package_version_file(
+    "${version_config}" COMPATIBILITY SameMajorVersion
+)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * TARGETS_EXPORT_NAME
+#   * PROJECT_NAME
+configure_package_config_file(
+    "cmake/Config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${config_install_dir}"
+)
+
+# Targets:
+#   * header location after install: <prefix>/include/fdeep/fdeep.hpp
+#   * headers can be included by C++ code `#include <fdeep/fdeep.hpp>`
+install(
+    TARGETS fdeep
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    LIBRARY DESTINATION "lib"
+    ARCHIVE DESTINATION "lib"
+    RUNTIME DESTINATION "bin"
+    INCLUDES DESTINATION "${include_install_dir}"
+)
+
+# Headers:
+#   * include/fdeep/fdeep.hpp -> <prefix>/include/fdeep/fdeep.hpp
+install(
+    DIRECTORY "include/fdeep" # no trailing slash
+    DESTINATION "${include_install_dir}"
+)
+
+# Config
+#   * <prefix>/lib/cmake/frugally-deep/frugally-deepConfig.cmake
+#   * <prefix>/lib/cmake/frugally-deep/frugally-deepConfigVersion.cmake
+install(
+    FILES "${project_config}" "${version_config}"
+    DESTINATION "${config_install_dir}"
+)
+
+# Config
+#   * <prefix>/lib/cmake/frugally-deep/frugally-deepTargets.cmake
+install(
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}"
+)
+
+# }

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -1,0 +1,16 @@
+add_compile_options(-Wall
+  -Wextra
+  -pedantic
+  -Werror
+  -Weffc++
+  -Wconversion
+  -Wsign-conversion
+  -Wctor-dtor-privacy
+  -Wreorder
+  -Wold-style-cast
+  -Wparentheses
+  )
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,89 +1,90 @@
 message(STATUS "Building Unit Tests ${UNITTEST}")
 
+if(NOT DEFINED ENV{TRAVIS}) # Do not use full model on travis since it takes too long.
+  set(full_test_default ON)
+else()
+  set(full_test_default OFF)
+endif()
+
+option(FDEEP_BUILD_FULL_TEST "Build full model tests" ${full_test_default})
+
 add_custom_command ( OUTPUT test_model_small.h5
-                     COMMAND bash -c "python3 ../keras_export/generate_test_models.py small test_model_small.h5"
+                     COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/generate_test_models.py small test_model_small.h5"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
 
 add_custom_command ( OUTPUT test_model_sequential.h5
-                     COMMAND bash -c "python3 ../keras_export/generate_test_models.py sequential test_model_sequential.h5"
+                     COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/generate_test_models.py sequential test_model_sequential.h5"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
 
-if(NOT DEFINED ENV{TRAVIS}) # Do not use full model on travis since it takes too long.
-add_custom_command ( OUTPUT test_model_full.h5
-                     COMMAND bash -c "python3 ../keras_export/generate_test_models.py full test_model_full.h5"
-                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
+if(FDEEP_BUILD_FULL_TEST)
+    add_custom_command ( OUTPUT test_model_full.h5
+                         COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/generate_test_models.py full test_model_full.h5"
+                         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
 endif()
 
 add_custom_command ( OUTPUT readme_example_model.h5
-                     COMMAND bash -c "python3 ../test/readme_example_generate.py"
+                     COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/test/readme_example_generate.py"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
 
 add_custom_command ( OUTPUT test_model_small.json
                      DEPENDS test_model_small.h5
-                     COMMAND bash -c "python3 ../keras_export/convert_model.py test_model_small.h5 test_model_small.json"
+                     COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/convert_model.py test_model_small.h5 test_model_small.json"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
 
 add_custom_command ( OUTPUT test_model_sequential.json
                      DEPENDS test_model_sequential.h5
-                     COMMAND bash -c "python3 ../keras_export/convert_model.py test_model_sequential.h5 test_model_sequential.json"
+                     COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/convert_model.py test_model_sequential.h5 test_model_sequential.json"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
 
-if(NOT DEFINED ENV{TRAVIS})
-add_custom_command ( OUTPUT test_model_full.json
-                     DEPENDS test_model_full.h5
-                     COMMAND bash -c "python3 ../keras_export/convert_model.py test_model_full.h5 test_model_full.json"
-                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
+if(FDEEP_BUILD_FULL_TEST)
+    add_custom_command ( OUTPUT test_model_full.json
+                         DEPENDS test_model_full.h5
+                         COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/convert_model.py test_model_full.h5 test_model_full.json"
+                         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
 endif()
 
 add_custom_command ( OUTPUT readme_example_model.json
                      DEPENDS readme_example_model.h5
-                     COMMAND bash -c "python3 ../keras_export/convert_model.py readme_example_model.h5 readme_example_model.json"
+                     COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/convert_model.py readme_example_model.h5 readme_example_model.json"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
 
-find_package(doctest REQUIRED)
+hunter_add_package(doctest)
+find_package(doctest CONFIG REQUIRED)
 
-macro(_add_test _NAME)
+macro(_add_test _NAME _DEPENDS)
+    add_custom_target(${_NAME}_data DEPENDS ${_DEPENDS})
     add_executable(${_NAME} ${_NAME}.cpp)
+    add_dependencies(${_NAME} ${_NAME}_data)
     add_test(NAME ${_NAME} COMMAND ${_NAME})
-    target_include_directories(${_NAME} SYSTEM PUBLIC ${doctest_INCLUDE_DIR})
-    target_link_libraries(${_NAME} ${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(${_NAME} fdeep Threads::Threads doctest::doctest)
 endmacro()
 
-_add_test(test_model_small_test)
-_add_test(test_model_sequential_test)
-if(NOT DEFINED ENV{TRAVIS})
-_add_test(test_model_full_test)
-_add_test(test_model_full_test_double)
+_add_test(test_model_small_test test_model_small.json)
+_add_test(test_model_sequential_test test_model_sequential.json)
+if(FDEEP_BUILD_FULL_TEST)
+  _add_test(test_model_full_test test_model_full.json)
+  _add_test(test_model_full_test_double test_model_full.json)
 endif()
-_add_test(readme_example_main)
+_add_test(readme_example_main readme_example_model.json)
 
-if(NOT DEFINED ENV{TRAVIS})
-add_custom_target(unittest
-    DEPENDS test_model_small.json
-    DEPENDS test_model_sequential.json
-    DEPENDS test_model_full.json
-    DEPENDS readme_example_model.json
-
+if(FDEEP_BUILD_FULL_TEST)
+  add_custom_target(unittest
     COMMAND test_model_small_test
     COMMAND test_model_sequential_test
     COMMAND test_model_full_test
     COMMAND test_model_full_test_double
     COMMAND readme_example_main
 
-    COMMENT "Running unittests\n\n"
+    COMMENT "Creating data for unittests\n\n"
     VERBATIM
-)
+    )
 else()
-add_custom_target(unittest
-    DEPENDS test_model_small.json
-    DEPENDS test_model_sequential.json
-    DEPENDS readme_example_model.json
-
+  add_custom_target(unittest
     COMMAND test_model_small_test
     COMMAND test_model_sequential_test
     COMMAND readme_example_main
 
-    COMMENT "Running unittests\n\n"
+    COMMENT "Creating data for unittests\n\n"
     VERBATIM
-)
+    )
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,7 +75,7 @@ if(FDEEP_BUILD_FULL_TEST)
     COMMAND test_model_full_test_double
     COMMAND readme_example_main
 
-    COMMENT "Creating data for unittests\n\n"
+    COMMENT "Running unittests\n\n"
     VERBATIM
     )
 else()
@@ -84,7 +84,7 @@ else()
     COMMAND test_model_sequential_test
     COMMAND readme_example_main
 
-    COMMENT "Creating data for unittests\n\n"
+    COMMENT "Running unittests\n\n"
     VERBATIM
     )
 endif()


### PR DESCRIPTION
This PR mirrors cmake pkgconfig changes from https://github.com/Dobiasd/FunctionalPlus/pull/116 in this repository.

* add/adapt pkgconfig boilerplate from https://github.com/forexample/package-example
* add a logical CMake INTERFACE target for fdeep (`add_library(fdeep INTERFACE)`), and provide matching `target_include_directories(…)` for build tree internal header use
* move compiler settings to optional (`FDEEP_USE_TOOLCHAIN` cmake option) internal toolchain.cmake file (allow user to override with consistent top level multi-package toolchain)
* move PROJECT_VERSION to project( … VERSION … )
* rename UNITTEST to FDEEP_BUILD_UNITTTEST
* add FDEEP_BUILD_FULL_TEST cmake option to toggle support for full tests so it can be disabled on slow machines (even when not using travis)
* add FDEEP_USE_DOUBLE option w/ matching target_compile_definitions for "sticky" option to be inherited by package consumer through `target_link_libraries(foo PUBLIC frugally-deep::fdeep)`
* add top level CMake CONFIG mode package use
  + `find_package(XYZ CONFIG REQUIRED)` # where XYZ == FunctionalPlus,Eigen,nlohmann_json,Threads
  + `target_link_libraries(fdeep INTERFACE Threads::Threads FunctionalPlus::fplus Eigen3::Eigen nlohmann_json)` # as separate calls
* add explicit generated input file dependency to each add_test() call so they will run directly from ctest as `cd build_tree && ctest` in addition to the `unittest` target
* update unit tests to use `doctest::doctest` as explicit CONFIG mode dependency: (same pkgconfig stuff used here https://github.com/onqtam/doctest/blob/b40b7e799deabac916d631d181a7f19f3060acc5/CMakeLists.txt#L39-L82)
* introduce FDEEP_TOP_DIR from top CMakeLists.txt so they can be run when the build tree != src tree
* update README + travis
* add hunter.cmake file for optional hunter use (default HUNTER_ENABLED=OFF)
* .gitignore : (*~|_*)
