### PR TITLE
Prelu support

### DIFF
--- a/include/fdeep/fdeep.hpp
+++ b/include/fdeep/fdeep.hpp
@@ -36,6 +36,7 @@
 #include "fdeep/layers/input_layer.hpp"
 #include "fdeep/layers/layer.hpp"
 #include "fdeep/layers/leaky_relu_layer.hpp"
+#include "fdeep/layers/prelu_layer.hpp"
 #include "fdeep/layers/linear_layer.hpp"
 #include "fdeep/layers/max_pooling_2d_layer.hpp"
 #include "fdeep/layers/maximum_layer.hpp"

--- a/include/fdeep/import_model.hpp
+++ b/include/fdeep/import_model.hpp
@@ -674,7 +674,7 @@ inline layer_ptr create_leaky_relu_layer_isolated(
 }
 
 inline layer_ptr create_prelu_layer(
-    const get_param_f& get_param, const get_global_param_f&, const nlohmann::json& data,
+    const get_param_f& get_param, const get_global_param_f&, const nlohmann::json&,
     const std::string& name)
 {
     float_vec alpha;

--- a/include/fdeep/import_model.hpp
+++ b/include/fdeep/import_model.hpp
@@ -673,6 +673,15 @@ inline layer_ptr create_leaky_relu_layer_isolated(
     return create_leaky_relu_layer(get_param, get_global_param, data, name);
 }
 
+inline layer_ptr create_prelu_layer(
+    const get_param_f& get_param, const get_global_param_f&, const nlohmann::json& data,
+    const std::string& name)
+{
+    float_vec alpha;
+    alpha = decode_floats(get_param(name, "alpha"));
+    return std::make_shared<prelu_layer>(name, alpha);
+}
+
 inline activation_layer_ptr create_elu_layer(
     const get_param_f&, const get_global_param_f&, const nlohmann::json& data,
     const std::string& name)
@@ -766,6 +775,7 @@ inline layer_ptr create_layer(const get_param_f& get_param,
             {"BatchNormalization", create_batch_normalization_layer},
             {"Dropout", create_dropout_layer},
             {"LeakyReLU", create_leaky_relu_layer_isolated},
+            {"PReLU", create_prelu_layer },
             {"ELU", create_elu_layer_isolated},
             {"MaxPooling1D", create_max_pooling_2d_layer},
             {"MaxPooling2D", create_max_pooling_2d_layer},

--- a/include/fdeep/layers/prelu_layer.hpp
+++ b/include/fdeep/layers/prelu_layer.hpp
@@ -1,0 +1,54 @@
+// Copyright 2016, Tobias Hermann.
+// https://github.com/Dobiasd/frugally-deep
+// Distributed under the MIT License.
+// (See accompanying LICENSE file or at
+//  https://opensource.org/licenses/MIT)
+
+#pragma once
+
+#include "fdeep/layers/layer.hpp"
+
+namespace fdeep {
+    namespace internal
+    {
+
+        class prelu_layer : public layer
+        {
+        public:
+            explicit prelu_layer(const std::string& name, const float_vec& alpha) :
+                layer(name), alpha_(alpha)
+            {
+            }
+        protected:
+            float_vec alpha_;
+            tensor3s apply_impl(const tensor3s& input) const override
+            {
+                const auto my_shared_ref = fplus::make_shared_ref<std::vector<float>>(alpha_);
+                fdeep::tensor3 alpha_tensor3(input[0].shape(), my_shared_ref);
+                std::cout << "alpha_tensor shape"<< fdeep::show_shape3(input[0].shape())<<" values " << fdeep::show_tensor3(alpha_tensor3) << std::endl;
+
+                fdeep::tensor3 out(input[0].shape(), 1.0f);
+                for (int x = 0; x < out.shape().width_; x++)
+                {
+                    for (int y = 0; y < out.shape().height_; y++)
+                    {
+                        for (int z = 0; z < out.shape().depth_; z++)
+                        {
+                            if (input[0].get(z, y, x) > 0)
+                            {
+                                out.set(z, y, x, input[0].get(z, y, x));
+                            }
+                            else
+                            {
+                                out.set(z, y, x, alpha_tensor3.get(z, y, x) * input[0].get(z, y, x));
+                            }
+                            std::cout << "tensor " << alpha_tensor3.get(z, y, x) << " vector " << alpha_[z*out.shape().height_*out.shape().width_ + y * out.shape().width_ + x] << std::endl;
+                        }
+                    }
+                }
+                return { out };
+            }
+        };
+
+    }
+} // namespace fdeep, namespace internal

--- a/include/fdeep/layers/prelu_layer.hpp
+++ b/include/fdeep/layers/prelu_layer.hpp
@@ -25,14 +25,14 @@ namespace fdeep {
             {
                 const auto my_shared_ref = fplus::make_shared_ref<std::vector<float>>(alpha_);
                 fdeep::tensor3 alpha_tensor3(input[0].shape(), my_shared_ref);
-                std::cout << "alpha_tensor shape"<< fdeep::show_shape3(input[0].shape())<<" values " << fdeep::show_tensor3(alpha_tensor3) << std::endl;
+                //std::cout << "alpha_tensor shape"<< fdeep::show_shape3(input[0].shape())<<" values " << fdeep::show_tensor3(alpha_tensor3) << std::endl;
 
                 fdeep::tensor3 out(input[0].shape(), 1.0f);
-                for (int x = 0; x < out.shape().width_; x++)
+                for (std::size_t x = 0; x < out.shape().width_; ++x)
                 {
-                    for (int y = 0; y < out.shape().height_; y++)
+                    for (std::size_t y = 0; y < out.shape().height_; ++y)
                     {
-                        for (int z = 0; z < out.shape().depth_; z++)
+                        for (std::size_t z = 0; z < out.shape().depth_; ++z)
                         {
                             if (input[0].get(z, y, x) > 0)
                             {
@@ -42,7 +42,7 @@ namespace fdeep {
                             {
                                 out.set(z, y, x, alpha_tensor3.get(z, y, x) * input[0].get(z, y, x));
                             }
-                            std::cout << "tensor " << alpha_tensor3.get(z, y, x) << " vector " << alpha_[z*out.shape().height_*out.shape().width_ + y * out.shape().width_ + x] << std::endl;
+                            //std::cout << "tensor " << alpha_tensor3.get(z, y, x) << " vector " << alpha_[z*out.shape().height_*out.shape().width_ + y * out.shape().width_ + x] << std::endl;
                         }
                     }
                 }

--- a/include/fdeep/layers/prelu_layer.hpp
+++ b/include/fdeep/layers/prelu_layer.hpp
@@ -16,18 +16,16 @@ namespace fdeep {
         {
         public:
             explicit prelu_layer(const std::string& name, const float_vec& alpha) :
-                layer(name), alpha_(alpha)
+                layer(name), alpha_(fplus::make_shared_ref<float_vec>(alpha))
             {
             }
         protected:
-            float_vec alpha_;
+            fdeep::shared_float_vec alpha_;
             tensor3s apply_impl(const tensor3s& input) const override
             {
-                const auto my_shared_ref = fplus::make_shared_ref<std::vector<float>>(alpha_);
-                fdeep::tensor3 alpha_tensor3(input[0].shape(), my_shared_ref);
-                //std::cout << "alpha_tensor shape"<< fdeep::show_shape3(input[0].shape())<<" values " << fdeep::show_tensor3(alpha_tensor3) << std::endl;
-
+                fdeep::tensor3 alpha_tensor3(input[0].shape(), alpha_);
                 fdeep::tensor3 out(input[0].shape(), 1.0f);
+
                 for (std::size_t x = 0; x < out.shape().width_; ++x)
                 {
                     for (std::size_t y = 0; y < out.shape().height_; ++y)
@@ -42,7 +40,6 @@ namespace fdeep {
                             {
                                 out.set(z, y, x, alpha_tensor3.get(z, y, x) * input[0].get(z, y, x));
                             }
-                            //std::cout << "tensor " << alpha_tensor3.get(z, y, x) << " vector " << alpha_[z*out.shape().height_*out.shape().width_ + y * out.shape().width_ + x] << std::endl;
                         }
                     }
                 }

--- a/keras_export/convert_model.py
+++ b/keras_export/convert_model.py
@@ -9,6 +9,7 @@ import sys
 
 import numpy as np
 
+import keras
 from keras.models import load_model
 from keras import backend as K
 
@@ -292,6 +293,16 @@ def show_dense_layer(layer):
         result['bias'] = encode_floats(bias)
     return result
 
+def show_prelu_layer(layer):
+    """Serialize prelu layer to dict"""
+    weights = layer.get_weights()
+    assert len(weights) == 1
+    print (weights[0].shape)
+    weights_flat = weights[0].flatten()
+    result = {
+        'alpha': encode_floats(weights_flat)
+    }
+    return result
 
 def get_dict_keys(d):
     """Return keys of a dictionary"""
@@ -327,7 +338,8 @@ def get_all_weights(model):
         'SeparableConv2D': show_separable_conv_2d_layer,
         'DepthwiseConv2D': show_depthwise_conv_2d_layer,
         'BatchNormalization': show_batch_normalization_layer,
-        'Dense': show_dense_layer
+        'Dense': show_dense_layer,
+        'PReLU': show_prelu_layer
     }
     result = {}
     layers = model.layers

--- a/keras_export/convert_model.py
+++ b/keras_export/convert_model.py
@@ -297,8 +297,14 @@ def show_prelu_layer(layer):
     """Serialize prelu layer to dict"""
     weights = layer.get_weights()
     assert len(weights) == 1
-    print (weights[0].shape)
-    weights_flat = weights[0].flatten()
+    if len(weights[0].shape) == 3:
+        weights_flat = np.swapaxes(np.swapaxes(weights[0], 2, 1), 1, 0).flatten()
+    elif len(weights[0].shape) == 2:
+        weights_flat = np.swapaxes(weights[0], 1, 0).flatten()
+    elif len(weights[0].shape) == 1:
+        weights_flat = weights[0].flatten()
+    else:
+        assert False
     result = {
         'alpha': encode_floats(weights_flat)
     }

--- a/keras_export/generate_test_models.py
+++ b/keras_export/generate_test_models.py
@@ -111,6 +111,10 @@ def get_test_model_small():
     outputs.append(DepthwiseConv2D(2, (3, 3), use_bias=True)(inputs[1]))
     outputs.append(DepthwiseConv2D(2, (3, 3), use_bias=False)(inputs[1]))
 
+    outputs.append(keras.layers.PReLU()(inputs[0]))
+    outputs.append(keras.layers.PReLU()(inputs[1]))
+    outputs.append(keras.layers.PReLU()(inputs[2]))
+
     #outputs.append(Conv2DTranspose(2, (3, 3), padding='valid')(inputs[1]))
 
     model = Model(inputs=inputs, outputs=outputs, name='test_model_small')

--- a/keras_export/generate_test_models.py
+++ b/keras_export/generate_test_models.py
@@ -115,6 +115,9 @@ def get_test_model_small():
     outputs.append(keras.layers.PReLU()(inputs[1]))
     outputs.append(keras.layers.PReLU()(inputs[2]))
 
+    outputs.append(keras.layers.PReLU()(Conv1D(2, 3, padding='valid')(inputs[0])))
+    outputs.append(keras.layers.PReLU()(Conv2D(2, (5, 7), padding='valid')(inputs[1])))
+
     #outputs.append(Conv2DTranspose(2, (3, 3), padding='valid')(inputs[1]))
 
     model = Model(inputs=inputs, outputs=outputs, name='test_model_small')


### PR DESCRIPTION
Hi Tobias, I am trying to add PReLU layer support to fdeep. With the modifications so far the networks pass the test when loading the json file in most cases. The only case where it does not pass the test is when the PReLU layer comes after a conv layer, which happens to be quite often and also in the network I want to use this for. I don't really understand how the layer before influences a layer coming behind it.
I know that what I have so far can be more optimized and is far from perfect, but the first step would be to get it running and get the same results as in keras. Do you have any ideas what might be the problem?