### PR TITLE
Remove test for division by zero in sigmoid activation

### DIFF
--- a/include/fdeep/layers/sigmoid_layer.hpp
+++ b/include/fdeep/layers/sigmoid_layer.hpp
@@ -24,13 +24,8 @@ public:
 protected:
     static float_type activation_function(float_type x)
     {
-        float_type divisor = 1 + std::exp(-x);
-        if (divisor == 0)
-        {
-            divisor = std::numeric_limits<float_type>::min();
-        }
-        return 1 / divisor;
-    };
+        return 1 / (1 + std::exp(-x));
+    }
     tensor3 transform_input(const tensor3& in_vol) const override
     {
         return transform_tensor3(activation_function, in_vol);


### PR DESCRIPTION
Simple observation that e(-x) >= 0 makes it possible to remove the divisor ==0 test.

NB: My first pull request. Look forward to make more contributions to this wonderful library. Keep up the good work!