### PR TITLE
Catch overflow in float (FDEEP_FLOAT_TYPE) in the softmax summation

### DIFF
--- a/include/fdeep/layers/softmax_layer.hpp
+++ b/include/fdeep/layers/softmax_layer.hpp
@@ -43,7 +43,11 @@ protected:
                 {
                     sum += output.get(z_class, y, x);
                 }
-                assertion(sum != 0, "Invalid divisor in softmax layer. Try using\n#define FDEEP_FLOAT_TYPE double\nbefore\n#include \"fdeep/fdeep.hpp\"\nIf you receive this error while using fdeep::load_model(filepath) try fdeep::load_model(filepath, false) instead to skip the verification step.");
+                assertion(sum != 0 && !std::isinf(sum), "Invalid divisor in softmax layer. Try using\n"
+                                                        "#define FDEEP_FLOAT_TYPE double\n"
+                                                        "before\n"
+                                                        "#include \"fdeep/fdeep.hpp\"\n"
+                                                        "If you receive this error while using fdeep::load_model(filepath) try fdeep::load_model(filepath, false) instead to skip the verification step.");
                 // Divide the unnormalized values of each pixel by the stacks sum.
                 for (size_t z_class = 0; z_class < input.shape().depth_; ++z_class)
                 {


### PR DESCRIPTION
Large models with random inputs cause `float` to overflow and cause errors in predictions. Including the test for `sum==inf` at the expense of extra check at each summation step.
Shouldn't occur in regular predictions with real data or if the FDEEP_FLOAT_TYPE is changed to `double` as the assertion suggests.

Reference example that promted this PR: https://gist.github.com/Dobiasd/16edaf183609bef3864a8235f80583b0

Overflow occurs with `FDEEP_FLOAT_TYPE float`