### PR TITLE
Add pooling layer parameter "channels_first"

### DIFF
--- a/include/fdeep/convolution.hpp
+++ b/include/fdeep/convolution.hpp
@@ -148,13 +148,14 @@ inline convolution_config preprocess_convolution(
     const shape2& strides,
     padding pad_type,
     bool use_offset,
-    const shape5& input_shape)
+    std::size_t input_shape_height,
+    std::size_t input_shape_width)
 {
     // https://www.tensorflow.org/api_guides/python/nn#Convolution
     const int filter_height = static_cast<int>(filter_shape.height_);
     const int filter_width = static_cast<int>(filter_shape.width_);
-    const int in_height = static_cast<int>(input_shape.height_);
-    const int in_width = static_cast<int>(input_shape.width_);
+    const int in_height = static_cast<int>(input_shape_height);
+    const int in_width = static_cast<int>(input_shape_width);
     const int strides_y = static_cast<int>(strides.height_);
     const int strides_x = static_cast<int>(strides.width_);
 
@@ -221,7 +222,7 @@ inline tensor5 convolve(
 
     const auto conv_cfg = preprocess_convolution(
         filter_mat.filter_shape_.without_depth(),
-        strides, pad_type, use_offset, input.shape());
+        strides, pad_type, use_offset, input.shape().height_, input.shape().width_);
 
     const std::size_t offset_y = conv_cfg.offset_y_;
     const std::size_t offset_x = conv_cfg.offset_x_;

--- a/include/fdeep/import_model.hpp
+++ b/include/fdeep/import_model.hpp
@@ -38,6 +38,8 @@
 #include "fdeep/layers/depthwise_conv_2d_layer.hpp"
 #include "fdeep/layers/elu_layer.hpp"
 #include "fdeep/layers/flatten_layer.hpp"
+#include "fdeep/layers/global_average_pooling_1d_layer.hpp"
+#include "fdeep/layers/global_max_pooling_1d_layer.hpp"
 #include "fdeep/layers/global_average_pooling_2d_layer.hpp"
 #include "fdeep/layers/global_max_pooling_2d_layer.hpp"
 #include "fdeep/layers/hard_sigmoid_layer.hpp"
@@ -516,6 +518,16 @@ inline layer_ptr create_average_pooling_2d_layer(
         padding_same_uses_offset);
 }
 
+inline layer_ptr create_global_max_pooling_1d_layer(
+    const get_param_f&, const get_global_param_f&, const nlohmann::json& data,
+    const std::string& name)
+{
+    const bool channels_first = json_obj_has_member(data, "config")
+        && json_object_get(data["config"], "data_format", std::string("channels_last")) == "channels_first";
+
+    return std::make_shared<global_max_pooling_1d_layer>(name, channels_first);
+}
+
 inline layer_ptr create_global_max_pooling_2d_layer(
     const get_param_f&, const get_global_param_f&, const nlohmann::json& data,
     const std::string& name)
@@ -524,6 +536,16 @@ inline layer_ptr create_global_max_pooling_2d_layer(
         && json_object_get(data["config"], "data_format", std::string("channels_last")) == "channels_first";
 
     return std::make_shared<global_max_pooling_2d_layer>(name, channels_first);
+}
+
+inline layer_ptr create_global_average_pooling_1d_layer(
+    const get_param_f&, const get_global_param_f&, const nlohmann::json& data,
+    const std::string& name)
+{
+    const bool channels_first = json_obj_has_member(data, "config")
+        && json_object_get(data["config"], "data_format", std::string("channels_last")) == "channels_first";
+
+    return std::make_shared<global_average_pooling_1d_layer>(name, channels_first);
 }
 
 inline layer_ptr create_global_average_pooling_2d_layer(
@@ -1023,9 +1045,9 @@ inline layer_ptr create_layer(const get_param_f& get_param,
             {"MaxPooling2D", create_max_pooling_2d_layer},
             {"AveragePooling1D", create_average_pooling_2d_layer},
             {"AveragePooling2D", create_average_pooling_2d_layer},
-            {"GlobalMaxPooling1D", create_global_max_pooling_2d_layer},
+            {"GlobalMaxPooling1D", create_global_max_pooling_1d_layer},
             {"GlobalMaxPooling2D", create_global_max_pooling_2d_layer},
-            {"GlobalAveragePooling1D", create_global_average_pooling_2d_layer},
+            {"GlobalAveragePooling1D", create_global_average_pooling_1d_layer},
             {"GlobalAveragePooling2D", create_global_average_pooling_2d_layer},
             {"UpSampling1D", create_upsampling_2d_layer},
             {"UpSampling2D", create_upsampling_2d_layer},

--- a/include/fdeep/layers/average_pooling_2d_layer.hpp
+++ b/include/fdeep/layers/average_pooling_2d_layer.hpp
@@ -17,16 +17,32 @@ namespace fdeep { namespace internal
 FDEEP_FORCE_INLINE tensor5 average_pool_2d(
     std::size_t pool_height, std::size_t pool_width,
     std::size_t strides_y, std::size_t strides_x,
+    bool channels_first,
     padding pad_type,
     bool use_offset,
     const tensor5& in)
 {
     const float_type invalid = std::numeric_limits<float_type>::lowest();
 
+    const std::size_t feature_count = channels_first
+        ? in.shape().height_
+        : in.shape().depth_
+        ;
+
+    const std::size_t in_height = channels_first
+        ? in.shape().width_
+        : in.shape().height_
+        ;
+
+    const std::size_t in_width = channels_first
+        ? in.shape().depth_
+        : in.shape().width_
+        ;
+
     const auto conv_cfg = preprocess_convolution(
         shape2(pool_height, pool_width),
         shape2(strides_y, strides_x),
-        pad_type, use_offset, in.shape());
+        pad_type, use_offset, in_height, in_width);
 
     int pad_top_int = static_cast<int>(conv_cfg.pad_top_);
     int pad_left_int = static_cast<int>(conv_cfg.pad_left_);
@@ -35,44 +51,82 @@ FDEEP_FORCE_INLINE tensor5 average_pool_2d(
     const std::size_t out_height = conv_cfg.out_height_;
     const std::size_t out_width = conv_cfg.out_width_;
 
-    tensor5 out(shape5(1, 1, out_height, out_width, in.shape().depth_), 0);
-    for (std::size_t y = 0; y < out.shape().height_; ++y)
+    if (channels_first)
     {
-        for (std::size_t x = 0; x < out.shape().width_; ++x)
+        tensor5 out(shape5(1, 1, feature_count, out_height, out_width), 0);
+
+        for (std::size_t z = 0; z < feature_count; ++z)
         {
-            for (std::size_t z = 0; z < out.shape().depth_; ++z)
+            for (std::size_t y = 0; y < out_height; ++y)
             {
-                float_type val = 0;
-                std::size_t divisor = 0;
-                for (std::size_t yf = 0; yf < pool_height; ++yf)
+                for (std::size_t x = 0; x < out_width; ++x)
                 {
-                    int in_get_y = static_cast<int>(offset_y + strides_y * y + yf) - pad_top_int;
-                    for (std::size_t xf = 0; xf < pool_width; ++xf)
+                    float_type val = 0;
+                    std::size_t divisor = 0;
+                    for (std::size_t yf = 0; yf < pool_height; ++yf)
                     {
-                        int in_get_x = static_cast<int>(offset_x + strides_x * x + xf) - pad_left_int;
-                        const auto current = in.get_x_y_padded(invalid,
-                            in_get_y, in_get_x, z);
-                        if (current != invalid)
+                        int in_get_y = static_cast<int>(offset_y + strides_y * y + yf) - pad_top_int;
+                        for (std::size_t xf = 0; xf < pool_width; ++xf)
                         {
-                            val += current;
-                            divisor += 1;
+                            int in_get_x = static_cast<int>(offset_x + strides_x * x + xf) - pad_left_int;
+                            const auto current = in.get_x_z_padded(invalid, z, in_get_y, in_get_x);
+                            if (current != invalid)
+                            {
+                                val += current;
+                                divisor += 1;
+                            }
                         }
                     }
+
+                    out.set(0, 0, z, y, x, val / static_cast<float_type>(divisor));
                 }
-                out.set(0, 0, y, x, z, val / static_cast<float_type>(divisor));
             }
         }
+        return out;
     }
-    return out;
+    else
+    {
+        tensor5 out(shape5(1, 1, out_height, out_width, feature_count), 0);
+
+        for (std::size_t y = 0; y < out_height; ++y)
+        {
+            for (std::size_t x = 0; x < out_width; ++x)
+            {
+                for (std::size_t z = 0; z < feature_count; ++z)
+                {
+                    float_type val = 0;
+                    std::size_t divisor = 0;
+                    for (std::size_t yf = 0; yf < pool_height; ++yf)
+                    {
+                        int in_get_y = static_cast<int>(offset_y + strides_y * y + yf) - pad_top_int;
+                        for (std::size_t xf = 0; xf < pool_width; ++xf)
+                        {
+                            int in_get_x = static_cast<int>(offset_x + strides_x * x + xf) - pad_left_int;
+                            const auto current = in.get_y_x_padded(invalid,
+                                in_get_y, in_get_x, z);
+                            if (current != invalid)
+                            {
+                                val += current;
+                                divisor += 1;
+                            }
+                        }
+                    }
+
+                    out.set(0, 0, y, x, z, val / static_cast<float_type>(divisor));
+                }
+            }
+        }
+        return out;
+    }
 }
 
 class average_pooling_2d_layer : public pooling_2d_layer
 {
 public:
     explicit average_pooling_2d_layer(const std::string& name,
-        const shape2& pool_size, const shape2& strides, padding p,
+        const shape2& pool_size, const shape2& strides, bool channels_first, padding p,
         bool padding_valid_uses_offset, bool padding_same_uses_offset) :
-        pooling_2d_layer(name, pool_size, strides, p,
+        pooling_2d_layer(name, pool_size, strides, channels_first, p,
             padding_valid_uses_offset, padding_same_uses_offset)
     {
     }
@@ -80,14 +134,14 @@ protected:
     tensor5 pool(const tensor5& in) const override
     {
         if (pool_size_ == shape2(2, 2) && strides_ == shape2(2, 2))
-            return average_pool_2d(2, 2, 2, 2, padding_, use_offset(), in);
+            return average_pool_2d(2, 2, 2, 2, channels_first_, padding_, use_offset(), in);
         else if (pool_size_ == shape2(4, 4) && strides_ == shape2(4, 4))
-            return average_pool_2d(4, 4, 4, 4, padding_, use_offset(), in);
+            return average_pool_2d(4, 4, 4, 4, channels_first_, padding_, use_offset(), in);
         else
             return average_pool_2d(
                 pool_size_.height_, pool_size_.width_,
                 strides_.height_, strides_.width_,
-                padding_, use_offset(), in);
+                channels_first_, padding_, use_offset(), in);
     }
 };
 

--- a/include/fdeep/layers/global_average_pooling_2d_layer.hpp
+++ b/include/fdeep/layers/global_average_pooling_2d_layer.hpp
@@ -16,20 +16,35 @@ namespace fdeep { namespace internal
 class global_average_pooling_2d_layer : public global_pooling_2d_layer
 {
 public:
-    explicit global_average_pooling_2d_layer(const std::string& name) :
-    global_pooling_2d_layer(name)
+    explicit global_average_pooling_2d_layer(const std::string& name, bool channels_first) :
+    global_pooling_2d_layer(name, channels_first)
     {
     }
 protected:
     tensor5 pool(const tensor5& in) const override
     {
-        tensor5 out(shape5(1, 1, 1, 1, in.shape().depth_), 0);
-        for (std::size_t z = 0; z < in.shape().depth_; ++z)
+        const std::size_t feature_count = channels_first_
+            ? in.shape().height_
+            : in.shape().depth_
+            ;
+
+        const std::size_t in_height = channels_first_
+            ? in.shape().width_
+            : in.shape().height_
+            ;
+
+        const std::size_t in_width = channels_first_
+            ? in.shape().depth_
+            : in.shape().width_
+            ;
+
+        tensor5 out(shape5(1, 1, 1, 1, feature_count), 0);
+        for (std::size_t z = 0; z < feature_count; ++z)
         {
             float_type val = 0;
-            for (std::size_t y = 0; y < in.shape().height_; ++y)
+            for (std::size_t y = 0; y < in_height; ++y)
             {
-                for (std::size_t x = 0; x < in.shape().width_; ++x)
+                for (std::size_t x = 0; x < in_width; ++x)
                 {
                     val += in.get(0, 0, y, x, z);
                 }

--- a/include/fdeep/layers/global_average_pooling_2d_layer.hpp
+++ b/include/fdeep/layers/global_average_pooling_2d_layer.hpp
@@ -6,18 +6,18 @@
 
 #pragma once
 
-#include "fdeep/layers/global_pooling_2d_layer.hpp"
+#include "fdeep/layers/global_pooling_layer.hpp"
 
 #include <string>
 
 namespace fdeep { namespace internal
 {
 
-class global_average_pooling_2d_layer : public global_pooling_2d_layer
+class global_average_pooling_2d_layer : public global_pooling_layer
 {
 public:
     explicit global_average_pooling_2d_layer(const std::string& name, bool channels_first) :
-    global_pooling_2d_layer(name, channels_first)
+    global_pooling_layer(name, channels_first)
     {
     }
 protected:
@@ -46,11 +46,13 @@ protected:
             {
                 for (std::size_t x = 0; x < in_width; ++x)
                 {
-                    val += in.get(0, 0, y, x, z);
+                    if (channels_first_)
+                        val += in.get(0, 0, z, y, x);
+                    else
+                        val += in.get(0, 0, y, x, z);
                 }
             }
-            out.set(0, 0, 0, 0, z, val /
-                static_cast<float_type>(in.shape().without_depth().area()));
+            out.set(0, 0, 0, 0, z, val / static_cast<float_type>(in_height * in_width));
         }
         return out;
     }

--- a/include/fdeep/layers/global_max_pooling_1d_layer.hpp
+++ b/include/fdeep/layers/global_max_pooling_1d_layer.hpp
@@ -15,10 +15,10 @@
 namespace fdeep { namespace internal
 {
 
-class global_max_pooling_2d_layer : public global_pooling_layer
+class global_max_pooling_1d_layer : public global_pooling_layer
 {
 public:
-    explicit global_max_pooling_2d_layer(const std::string& name, bool channels_first) :
+    explicit global_max_pooling_1d_layer(const std::string& name, bool channels_first) :
     global_pooling_layer(name, channels_first)
     {
     }
@@ -26,16 +26,11 @@ protected:
     tensor5 pool(const tensor5& in) const override
     {
         const std::size_t feature_count = channels_first_
-            ? in.shape().height_
+            ? in.shape().width_
             : in.shape().depth_
             ;
 
-        const std::size_t in_height = channels_first_
-            ? in.shape().width_
-            : in.shape().height_
-            ;
-
-        const std::size_t in_width = channels_first_
+        const std::size_t step_count = channels_first_
             ? in.shape().depth_
             : in.shape().width_
             ;
@@ -44,15 +39,12 @@ protected:
         for (std::size_t z = 0; z < feature_count; ++z)
         {
             float_type val = std::numeric_limits<float_type>::lowest();
-            for (std::size_t y = 0; y < in_height; ++y)
+            for (std::size_t x = 0; x < step_count; ++x)
             {
-                for (std::size_t x = 0; x < in_width; ++x)
-                {
-                    if (channels_first_)
-                        val = std::max(val, in.get(0, 0, z, y, x));
-                    else
-                        val = std::max(val, in.get(0, 0, y, x, z));
-                }
+                if (channels_first_)
+                    val = std::max(val, in.get(0, 0, 0, z, x));
+                else
+                    val = std::max(val, in.get(0, 0, 0, x, z));
             }
             out.set(0, 0, 0, 0, z, val);
         }

--- a/include/fdeep/layers/global_max_pooling_2d_layer.hpp
+++ b/include/fdeep/layers/global_max_pooling_2d_layer.hpp
@@ -18,20 +18,35 @@ namespace fdeep { namespace internal
 class global_max_pooling_2d_layer : public global_pooling_2d_layer
 {
 public:
-    explicit global_max_pooling_2d_layer(const std::string& name) :
-    global_pooling_2d_layer(name)
+    explicit global_max_pooling_2d_layer(const std::string& name, bool channels_first) :
+    global_pooling_2d_layer(name, channels_first)
     {
     }
 protected:
     tensor5 pool(const tensor5& in) const override
     {
-        tensor5 out(shape5(1, 1, 1, 1, in.shape().depth_), 0);
-        for (std::size_t z = 0; z < out.shape().depth_; ++z)
+        const std::size_t feature_count = channels_first_
+            ? in.shape().height_
+            : in.shape().depth_
+            ;
+
+        const std::size_t in_height = channels_first_
+            ? in.shape().width_
+            : in.shape().height_
+            ;
+
+        const std::size_t in_width = channels_first_
+            ? in.shape().depth_
+            : in.shape().width_
+            ;
+
+        tensor5 out(shape5(1, 1, 1, 1, feature_count), 0);
+        for (std::size_t z = 0; z < feature_count; ++z)
         {
             float_type val = std::numeric_limits<float_type>::lowest();
-            for (std::size_t y = 0; y < in.shape().height_; ++y)
+            for (std::size_t y = 0; y < in_height; ++y)
             {
-                for (std::size_t x = 0; x < in.shape().width_; ++x)
+                for (std::size_t x = 0; x < in_width; ++x)
                 {
                     val = std::max(val, in.get(0, 0, y, x, z));
                 }

--- a/include/fdeep/layers/global_pooling_2d_layer.hpp
+++ b/include/fdeep/layers/global_pooling_2d_layer.hpp
@@ -22,8 +22,9 @@ namespace fdeep { namespace internal
 class global_pooling_2d_layer : public layer
 {
 public:
-    explicit global_pooling_2d_layer(const std::string& name) :
-        layer(name)
+    explicit global_pooling_2d_layer(const std::string& name, bool channels_first) :
+        layer(name),
+        channels_first_(channels_first)
     {
     }
 protected:
@@ -34,6 +35,8 @@ protected:
         return {pool(input)};
     }
     virtual tensor5 pool(const tensor5& input) const = 0;
+
+    bool channels_first_;
 };
 
 } } // namespace fdeep, namespace internal

--- a/include/fdeep/layers/global_pooling_layer.hpp
+++ b/include/fdeep/layers/global_pooling_layer.hpp
@@ -19,10 +19,10 @@ namespace fdeep { namespace internal
 {
 
 // Abstract base class for global pooling layers
-class global_pooling_2d_layer : public layer
+class global_pooling_layer : public layer
 {
 public:
-    explicit global_pooling_2d_layer(const std::string& name, bool channels_first) :
+    explicit global_pooling_layer(const std::string& name, bool channels_first) :
         layer(name),
         channels_first_(channels_first)
     {

--- a/include/fdeep/layers/max_pooling_2d_layer.hpp
+++ b/include/fdeep/layers/max_pooling_2d_layer.hpp
@@ -18,16 +18,32 @@ namespace fdeep { namespace internal
 FDEEP_FORCE_INLINE tensor5 max_pool_2d(
     std::size_t pool_height, std::size_t pool_width,
     std::size_t strides_y, std::size_t strides_x,
+    bool channels_first,
     padding pad_type,
     bool use_offset,
     const tensor5& in)
 {
     const float_type invalid = std::numeric_limits<float_type>::lowest();
 
+    const std::size_t feature_count = channels_first
+        ? in.shape().height_
+        : in.shape().depth_
+        ;
+
+    const std::size_t in_height = channels_first
+        ? in.shape().width_
+        : in.shape().height_
+        ;
+
+    const std::size_t in_width = channels_first
+        ? in.shape().depth_
+        : in.shape().width_
+        ;
+
     const auto conv_cfg = preprocess_convolution(
         shape2(pool_height, pool_width),
         shape2(strides_y, strides_x),
-        pad_type, use_offset, in.shape());
+        pad_type, use_offset, in_height, in_width);
 
     int pad_top_int = static_cast<int>(conv_cfg.pad_top_);
     int pad_left_int = static_cast<int>(conv_cfg.pad_left_);
@@ -36,39 +52,71 @@ FDEEP_FORCE_INLINE tensor5 max_pool_2d(
     const std::size_t out_height = conv_cfg.out_height_;
     const std::size_t out_width = conv_cfg.out_width_;
 
-    tensor5 out(shape5(1, 1, out_height, out_width, in.shape().depth_), 0);
-    for (std::size_t y = 0; y < out.shape().height_; ++y)
+    if (channels_first)
     {
-        for (std::size_t x = 0; x < out.shape().width_; ++x)
+        tensor5 out(shape5(1, 1, feature_count, out_height, out_width), 0);
+
+        for (std::size_t z = 0; z < feature_count; ++z)
         {
-            for (std::size_t z = 0; z < out.shape().depth_; ++z)
+            for (std::size_t y = 0; y < out_height; ++y)
             {
-                float_type val = std::numeric_limits<float_type>::lowest();
-                for (std::size_t yf = 0; yf < pool_height; ++yf)
+                for (std::size_t x = 0; x < out_width; ++x)
                 {
-                    int in_get_y = static_cast<int>(offset_y + strides_y * y + yf) - pad_top_int;
-                    for (std::size_t xf = 0; xf < pool_width; ++xf)
+                    float_type val = std::numeric_limits<float_type>::lowest();
+                    for (std::size_t yf = 0; yf < pool_height; ++yf)
                     {
-                        int in_get_x = static_cast<int>(offset_x + strides_x * x + xf) - pad_left_int;
-                        const auto current = in.get_x_y_padded(invalid,
-                            in_get_y, in_get_x, z);
-                        val = std::max(val, current);
+                        int in_get_y = static_cast<int>(offset_y + strides_y * y + yf) - pad_top_int;
+                        for (std::size_t xf = 0; xf < pool_width; ++xf)
+                        {
+                            int in_get_x = static_cast<int>(offset_x + strides_x * x + xf) - pad_left_int;
+                            const auto current = in.get_x_z_padded(invalid, z, in_get_y, in_get_x);
+                            val = std::max(val, current);
+                        }
                     }
+
+                    out.set(0, 0, z, y, x, val);
                 }
-                out.set(0, 0, y, x, z, val);
             }
         }
+        return out;
     }
-    return out;
+    else
+    {
+        tensor5 out(shape5(1, 1, out_height, out_width, feature_count), 0);
+
+        for (std::size_t y = 0; y < out_height; ++y)
+        {
+            for (std::size_t x = 0; x < out_width; ++x)
+            {
+                for (std::size_t z = 0; z < feature_count; ++z)
+                {
+                    float_type val = std::numeric_limits<float_type>::lowest();
+                    for (std::size_t yf = 0; yf < pool_height; ++yf)
+                    {
+                        int in_get_y = static_cast<int>(offset_y + strides_y * y + yf) - pad_top_int;
+                        for (std::size_t xf = 0; xf < pool_width; ++xf)
+                        {
+                            int in_get_x = static_cast<int>(offset_x + strides_x * x + xf) - pad_left_int;
+                            const auto current = in.get_y_x_padded(invalid, in_get_y, in_get_x, z);
+                            val = std::max(val, current);
+                        }
+                    }
+
+                    out.set(0, 0, y, x, z, val);
+                }
+            }
+        }
+        return out;
+    }
 }
 
 class max_pooling_2d_layer : public pooling_2d_layer
 {
 public:
     explicit max_pooling_2d_layer(const std::string& name,
-        const shape2& pool_size, const shape2& strides, padding p,
+        const shape2& pool_size, const shape2& strides, bool channels_first, padding p,
         bool padding_valid_uses_offset, bool padding_same_uses_offset) :
-        pooling_2d_layer(name, pool_size, strides, p,
+        pooling_2d_layer(name, pool_size, strides, channels_first, p,
             padding_valid_uses_offset, padding_same_uses_offset)
     {
     }
@@ -76,14 +124,14 @@ protected:
     tensor5 pool(const tensor5& in) const override
     {
         if (pool_size_ == shape2(2, 2) && strides_ == shape2(2, 2))
-            return max_pool_2d(2, 2, 2, 2, padding_, use_offset(), in);
+            return max_pool_2d(2, 2, 2, 2, channels_first_, padding_, use_offset(), in);
         else if (pool_size_ == shape2(4, 4) && strides_ == shape2(4, 4))
-            return max_pool_2d(4, 4, 4, 4, padding_, use_offset(), in);
+            return max_pool_2d(4, 4, 4, 4, channels_first_, padding_, use_offset(), in);
         else
             return max_pool_2d(
                 pool_size_.height_, pool_size_.width_,
                 strides_.height_, strides_.width_,
-                padding_, use_offset(), in);
+                channels_first_, padding_, use_offset(), in);
     }
 };
 

--- a/include/fdeep/layers/pooling_2d_layer.hpp
+++ b/include/fdeep/layers/pooling_2d_layer.hpp
@@ -24,11 +24,12 @@ class pooling_2d_layer : public layer
 {
 public:
     explicit pooling_2d_layer(const std::string& name,
-        const shape2& pool_size, const shape2& strides, padding p,
+        const shape2& pool_size, const shape2& strides, bool channels_first, padding p,
         bool padding_valid_uses_offset, bool padding_same_uses_offset) :
         layer(name),
         pool_size_(pool_size),
         strides_(strides),
+        channels_first_(channels_first),
         padding_(p),
         padding_valid_uses_offset_(padding_valid_uses_offset),
         padding_same_uses_offset_(padding_same_uses_offset)
@@ -53,6 +54,7 @@ protected:
 
     shape2 pool_size_;
     shape2 strides_;
+    bool channels_first_;
     padding padding_;
     bool padding_valid_uses_offset_;
     bool padding_same_uses_offset_;

--- a/include/fdeep/layers/softmax_layer.hpp
+++ b/include/fdeep/layers/softmax_layer.hpp
@@ -24,7 +24,7 @@ protected:
     tensor5 transform_input(const tensor5& input) const override
     {
         // Get unnormalized values of exponent function.
-        const auto ex = [this](float_type x) -> float_type
+        const auto ex = [](float_type x) -> float_type
         {
             return std::exp(x);
         };

--- a/include/fdeep/node.hpp
+++ b/include/fdeep/node.hpp
@@ -54,7 +54,7 @@ public:
     tensor5s get_output(const layer_ptrs& layers, output_dict& output_cache,
         const layer& layer) const
     {
-        const auto get_input = [this, &output_cache, &layers]
+        const auto get_input = [&output_cache, &layers]
             (const node_connection& conn) -> tensor5
         {
             return get_layer_output(layers, output_cache,

--- a/include/fdeep/tensor5.hpp
+++ b/include/fdeep/tensor5.hpp
@@ -56,24 +56,24 @@ public:
         return get(tensor5_pos(pos_dim_5, pos_dim_4, y, x, z));
     }
     float_type get_y_x_padded(float_type pad_value,
-        std::size_t y, std::size_t x, std::size_t z) const
+        int y, int x, std::size_t z) const
     {
-        if (y < 0 || y >= shape().height_ ||
-            x < 0 || x >= shape().width_)
+        if (y < 0 || y >= static_cast<int>(shape().height_) ||
+            x < 0 || x >= static_cast<int>(shape().width_))
         {
             return pad_value;
         }
-        return get(tensor5_pos(0, 0, y, x, z));
+        return get(tensor5_pos(0, 0, static_cast<std::size_t>(y), static_cast<std::size_t>(x), z));
     }
     float_type get_x_z_padded(float_type pad_value,
-        std::size_t y, std::size_t x, std::size_t z) const
+        std::size_t y, int x, int z) const
     {
-        if (x < 0 || x >= shape().width_ ||
-            z < 0 || z >= shape().depth_)
+        if (x < 0 || x >= static_cast<int>(shape().width_) ||
+            z < 0 || z >= static_cast<int>(shape().depth_))
         {
             return pad_value;
         }
-        return get(tensor5_pos(0, 0, y, x, z));
+        return get(tensor5_pos(0, 0, y, static_cast<std::size_t>(x), static_cast<std::size_t>(z)));
     }
     void set(const tensor5_pos& pos, float_type value)
     {

--- a/include/fdeep/tensor5.hpp
+++ b/include/fdeep/tensor5.hpp
@@ -55,16 +55,25 @@ public:
     {
         return get(tensor5_pos(pos_dim_5, pos_dim_4, y, x, z));
     }
-    float_type get_x_y_padded(float_type pad_value,
-        int y, int x, std::size_t z) const
+    float_type get_y_x_padded(float_type pad_value,
+        std::size_t y, std::size_t x, std::size_t z) const
     {
-        if (y < 0 || y >= static_cast<int>(shape().height_) ||
-            x < 0 || x >= static_cast<int>(shape().width_))
+        if (y < 0 || y >= shape().height_ ||
+            x < 0 || x >= shape().width_)
         {
             return pad_value;
         }
-        return get(tensor5_pos(0, 0,
-            static_cast<std::size_t>(y), static_cast<std::size_t>(x), z));
+        return get(tensor5_pos(0, 0, y, x, z));
+    }
+    float_type get_x_z_padded(float_type pad_value,
+        std::size_t y, std::size_t x, std::size_t z) const
+    {
+        if (x < 0 || x >= shape().width_ ||
+            z < 0 || z >= shape().depth_)
+        {
+            return pad_value;
+        }
+        return get(tensor5_pos(0, 0, y, x, z));
     }
     void set(const tensor5_pos& pos, float_type value)
     {

--- a/keras_export/convert_model.py
+++ b/keras_export/convert_model.py
@@ -462,12 +462,16 @@ def get_all_weights(model):
     layers = model.layers
     assert K.image_data_format() == 'channels_last'
     for layer in layers:
-        if hasattr(layer, 'data_format'):
-            assert layer.data_format == 'channels_last'
         layer_type = type(layer).__name__
         if layer_type in ['Model', 'Sequential']:
             result = merge_two_disjunct_dicts(result, get_all_weights(layer))
         else:
+            if hasattr(layer, 'data_format'):
+                if layer_type in ['AveragePooling1D','MaxPooling1D','AveragePooling2D','MaxPooling2D','GlobalAveragePooling1D','GlobalMaxPooling1D','GlobalAveragePooling2D','GlobalMaxPooling2D']:
+                    assert layer.data_format == 'channels_last' or layer.data_format == 'channels_first'
+                else:
+                    assert layer.data_format == 'channels_last'
+
             show_func = show_layer_functions.get(layer_type, None)
             name = layer.name
             assert is_ascii(name)

--- a/keras_export/generate_test_models.py
+++ b/keras_export/generate_test_models.py
@@ -354,7 +354,9 @@ def get_test_model_sequential():
     model = Sequential()
     model.add(Conv2D(8, (3, 3), activation='relu', input_shape=(32, 32, 3)))
     model.add(Conv2D(8, (3, 3), activation='relu'))
-    model.add(MaxPooling2D(pool_size=(2, 2)))
+    model.add(Permute((3,1,2)))
+    model.add(MaxPooling2D(pool_size=(2, 2), data_format="channels_first"))
+    model.add(Permute((2,3,1)))
     model.add(Dropout(0.25))
 
     model.add(Conv2D(16, (3, 3), activation='elu'))

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,10 @@ add_custom_command ( OUTPUT test_model_small.h5
                      COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/generate_test_models.py small test_model_small.h5"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
 
+add_custom_command ( OUTPUT test_model_pooling.h5
+                     COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/generate_test_models.py pooling test_model_pooling.h5"
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
+
 add_custom_command ( OUTPUT test_model_embedding.h5
                      COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/generate_test_models.py embedding test_model_embedding.h5"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
@@ -37,6 +41,11 @@ add_custom_command ( OUTPUT readme_example_model.h5
 add_custom_command ( OUTPUT test_model_small.json
                      DEPENDS test_model_small.h5
                      COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/convert_model.py test_model_small.h5 test_model_small.json"
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
+
+add_custom_command ( OUTPUT test_model_pooling.json
+                     DEPENDS test_model_pooling.h5
+                     COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/convert_model.py test_model_pooling.h5 test_model_pooling.json"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
 
 add_custom_command ( OUTPUT test_model_embedding.json
@@ -83,6 +92,7 @@ macro(_add_test _NAME _DEPENDS)
 endmacro()
 
 _add_test(test_model_small_test test_model_small.json)
+_add_test(test_model_pooling_test test_model_pooling.json)
 _add_test(test_model_embedding_test test_model_embedding.json)
 _add_test(test_model_recurrent_test test_model_recurrent.json)
 _add_test(test_model_variable_test test_model_variable.json)
@@ -96,6 +106,7 @@ _add_test(readme_example_main readme_example_model.json)
 if(FDEEP_BUILD_FULL_TEST)
   add_custom_target(unittest
     COMMAND test_model_small_test
+    COMMAND test_model_pooling_test
     COMMAND test_model_embedding_test
     COMMAND test_model_recurrent_test
     COMMAND test_model_variable_test
@@ -110,6 +121,7 @@ if(FDEEP_BUILD_FULL_TEST)
 else()
   add_custom_target(unittest
     COMMAND test_model_small_test
+    COMMAND test_model_pooling_test
     COMMAND test_model_embedding_test
     COMMAND test_model_recurrent_test
     COMMAND test_model_variable_test

--- a/test/test_model_pooling_test.cpp
+++ b/test/test_model_pooling_test.cpp
@@ -1,0 +1,20 @@
+// Copyright 2016, Tobias Hermann.
+// https://github.com/Dobiasd/frugally-deep
+// Distributed under the MIT License.
+// (See accompanying LICENSE file or at
+//  https://opensource.org/licenses/MIT)
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+#include <fdeep/fdeep.hpp>
+
+TEST_CASE("test_model_pooling_test, load_model")
+{
+    const auto model = fdeep::load_model("../test_model_pooling.json",
+        true, fdeep::cout_logger, static_cast<fdeep::float_type>(0.00001));
+    const auto multi_inputs = fplus::generate<std::vector<fdeep::tensor5s>>(
+        [&]() -> fdeep::tensor5s {return model.generate_dummy_inputs();},
+        10);
+    model.predict_multi(multi_inputs, false);
+    model.predict_multi(multi_inputs, true);
+}


### PR DESCRIPTION
This pull request adds support for the `data_format` parameter value `channels_first` for layers `AveragePooling1D`, `MaxPooling1D`, `AveragePooling2D`, `MaxPooling2D`, `GlobalAveragePooling1D`, `GlobalMaxPooling1D`, `GlobalAveragePooling2D` and `GlobalMaxPooling2D`.