### PR TITLE
Allow weights trained with CuDNNGRU to be used without GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Layer types typically used in image recognition/generation are supported, making
 
 * `Add`, `Concatenate`, `Subtract`, `Multiply`, `Average`, `Maximum`
 * `AveragePooling1D/2D`, `GlobalAveragePooling1D/2D`
-* `Bidirectional`, `Embedding`, `GRU`, `LSTM`, `TimeDistributed`
+* `Bidirectional`, `TimeDistributed`, `GRU`, `LSTM`, `CuDNNGRU`
 * `Conv1D/2D`, `SeparableConv2D`, `DepthwiseConv2D`
 * `Cropping1D/2D`, `ZeroPadding1D/2D`
 * `BatchNormalization`, `Dense`, `Flatten`
@@ -56,6 +56,7 @@ Layer types typically used in image recognition/generation are supported, making
 * `Sigmoid`, `Softmax`, `Softplus`, `Tanh`
 * `UpSampling1D/2D`
 * `Reshape`, `Permute`
+* `Embedding`
 
 
 ### Also supported
@@ -74,7 +75,6 @@ Layer types typically used in image recognition/generation are supported, making
 `Conv2DTranspose`,
 `Conv3D`,
 `ConvLSTM2D`,
-`CuDNNGRU`,
 `CuDNNLSTM`,
 `Cropping3D`,
 `Dot`,

--- a/include/fdeep/import_model.hpp
+++ b/include/fdeep/import_model.hpp
@@ -940,8 +940,12 @@ inline layer_ptr create_gru_layer(const get_param_f &get_param,
     auto&& config = data["config"];
     const std::size_t units = config["units"];
     const std::string unit_activation = json_object_get(config, "activation", std::string("tanh"));
-    const std::string recurrent_activation_default = data["class_name"] == "CuDNNGRU" ? "sigmoid" : "hard_sigmoid";
-    const std::string recurrent_activation = json_object_get(config, "recurrent_activation", recurrent_activation_default);
+    const std::string recurrent_activation = json_object_get(config,
+        "recurrent_activation",
+        data["class_name"] == "CuDNNGRU"
+            ? std::string("sigmoid")
+            : std::string("hard_sigmoid")
+    );
 
     const bool use_bias = json_object_get(config, "use_bias", true);
 
@@ -952,8 +956,10 @@ inline layer_ptr create_gru_layer(const get_param_f &get_param,
     const float_vec weights = decode_floats(get_param(name, "weights"));
     const float_vec recurrent_weights = decode_floats(get_param(name, "recurrent_weights"));
 
-    const bool reset_after_default = data["class_name"] == "CuDNNGRU";
-    const bool reset_after = json_object_get(config, "reset_after", reset_after_default);
+    bool reset_after = json_object_get(config,
+        "reset_after",
+        data["class_name"] == "CuDNNGRU"
+    );
     const bool return_sequences = json_object_get(config, "return_sequences", false);
 
     return std::make_shared<gru_layer>(name, units, unit_activation,
@@ -971,8 +977,12 @@ inline layer_ptr create_bidirectional_layer(const get_param_f& get_param,
     auto&& layer_config = layer["config"];
     const std::size_t units = layer_config["units"];
     const std::string unit_activation = json_object_get(layer_config, "activation", std::string("tanh"));
-    const std::string recurrent_activation_default = layer["class_name"] == "CuDNNGRU" || layer["class_name"] == "CuDNNLSTM"  ? "sigmoid" : "hard_sigmoid";
-    const std::string recurrent_activation = json_object_get(layer_config, "recurrent_activation", recurrent_activation_default);
+    const std::string recurrent_activation = json_object_get(layer_config,
+        "recurrent_activation",
+        layer["class_name"] == "CuDNNGRU" || layer["class_name"] == "CuDNNLSTM"
+            ? std::string("sigmoid")
+            : std::string("hard_sigmoid")
+    );
     const bool use_bias = json_object_get(layer_config, "use_bias", true);
     const std::string wrapped_layer_type = data["config"]["layer"]["class_name"];
 
@@ -991,8 +1001,10 @@ inline layer_ptr create_bidirectional_layer(const get_param_f& get_param,
     const float_vec forward_recurrent_weights = decode_floats(get_param(name, "forward_recurrent_weights"));
     const float_vec backward_recurrent_weights = decode_floats(get_param(name, "backward_recurrent_weights"));
 
-    const bool reset_after_default = layer["class_name"] == "CuDNNGRU";
-    const bool reset_after = json_object_get(layer_config, "reset_after", reset_after_default);
+    const bool reset_after = json_object_get(layer_config,
+        "reset_after",
+        layer["class_name"] == "CuDNNGRU"
+    );
     const bool return_sequences = json_object_get(layer_config, "return_sequences", false);
 
     return std::make_shared<bidirectional_layer>(name, merge_mode, units, unit_activation,

--- a/include/fdeep/import_model.hpp
+++ b/include/fdeep/import_model.hpp
@@ -913,10 +913,11 @@ inline layer_ptr create_lstm_layer(const get_param_f &get_param,
                                    const nlohmann::json &data,
                                    const std::string &name)
 {
-    const std::size_t units = data["config"]["units"];
-    const std::string unit_activation = data["config"]["activation"];
-    const std::string recurrent_activation = data["config"]["recurrent_activation"];
-    const bool use_bias = data["config"]["use_bias"];
+    auto&& config = data["config"];
+    const std::size_t units = config["units"];
+    const std::string unit_activation = json_object_get(config, "activation", std::string("tanh"));
+    const std::string recurrent_activation = json_object_get(config, "recurrent_activation", std::string("sigmoid"));
+    const bool use_bias = json_object_get(config, "use_bias", true);
 
     float_vec bias;
     if (use_bias)
@@ -924,7 +925,7 @@ inline layer_ptr create_lstm_layer(const get_param_f &get_param,
 
     const float_vec weights = decode_floats(get_param(name, "weights"));
     const float_vec recurrent_weights = decode_floats(get_param(name, "recurrent_weights"));
-    const bool return_sequences = data["config"]["return_sequences"];
+    const bool return_sequences = config["return_sequences"];
 
     return std::make_shared<lstm_layer>(name, units, unit_activation,
                                         recurrent_activation, use_bias, return_sequences,
@@ -936,10 +937,13 @@ inline layer_ptr create_gru_layer(const get_param_f &get_param,
                                   const nlohmann::json &data,
                                   const std::string &name)
 {
-    const std::size_t units = data["config"]["units"];
-    const std::string unit_activation = data["config"]["activation"];
-    const std::string recurrent_activation = data["config"]["recurrent_activation"];
-    const bool use_bias = data["config"]["use_bias"];
+    auto&& config = data["config"];
+    const std::size_t units = config["units"];
+    const std::string unit_activation = json_object_get(config, "activation", std::string("tanh"));
+    const std::string recurrent_activation_default = data["class_name"] == "CuDNNGRU" ? "sigmoid" : "hard_sigmoid";
+    const std::string recurrent_activation = json_object_get(config, "recurrent_activation", recurrent_activation_default);
+
+    const bool use_bias = json_object_get(config, "use_bias", true);
 
     float_vec bias;
     if (use_bias)
@@ -948,8 +952,8 @@ inline layer_ptr create_gru_layer(const get_param_f &get_param,
     const float_vec weights = decode_floats(get_param(name, "weights"));
     const float_vec recurrent_weights = decode_floats(get_param(name, "recurrent_weights"));
 
-    auto&& config = data["config"];
-    const bool reset_after = json_object_get(config, "reset_after", false);
+    const bool reset_after_default = data["class_name"] == "CuDNNGRU";
+    const bool reset_after = json_object_get(config, "reset_after", reset_after_default);
     const bool return_sequences = json_object_get(config, "return_sequences", false);
 
     return std::make_shared<gru_layer>(name, units, unit_activation,
@@ -963,10 +967,13 @@ inline layer_ptr create_bidirectional_layer(const get_param_f& get_param,
                                             const std::string& name)
 {
     const std::string merge_mode = data["config"]["merge_mode"];
-    const std::size_t units = data["config"]["layer"]["config"]["units"];
-    const std::string unit_activation = data["config"]["layer"]["config"]["activation"];
-    const std::string recurrent_activation = data["config"]["layer"]["config"]["recurrent_activation"];
-    const bool use_bias = data["config"]["layer"]["config"]["use_bias"];
+    auto&& layer = data["config"]["layer"];
+    auto&& layer_config = layer["config"];
+    const std::size_t units = layer_config["units"];
+    const std::string unit_activation = json_object_get(layer_config, "activation", std::string("tanh"));
+    const std::string recurrent_activation_default = layer["class_name"] == "CuDNNGRU" || layer["class_name"] == "CuDNNLSTM"  ? "sigmoid" : "hard_sigmoid";
+    const std::string recurrent_activation = json_object_get(layer_config, "recurrent_activation", recurrent_activation_default);
+    const bool use_bias = json_object_get(layer_config, "use_bias", true);
     const std::string wrapped_layer_type = data["config"]["layer"]["class_name"];
 
     float_vec forward_bias;
@@ -984,8 +991,8 @@ inline layer_ptr create_bidirectional_layer(const get_param_f& get_param,
     const float_vec forward_recurrent_weights = decode_floats(get_param(name, "forward_recurrent_weights"));
     const float_vec backward_recurrent_weights = decode_floats(get_param(name, "backward_recurrent_weights"));
 
-    auto&& layer_config = data["config"]["layer"]["config"];
-    const bool reset_after = json_object_get(layer_config, "reset_after", false);
+    const bool reset_after_default = layer["class_name"] == "CuDNNGRU";
+    const bool reset_after = json_object_get(layer_config, "reset_after", reset_after_default);
     const bool return_sequences = json_object_get(layer_config, "return_sequences", false);
 
     return std::make_shared<bidirectional_layer>(name, merge_mode, units, unit_activation,
@@ -1067,7 +1074,9 @@ inline layer_ptr create_layer(const get_param_f& get_param,
             {"Reshape", create_reshape_layer},
             {"Embedding", create_embedding_layer},
             {"LSTM", create_lstm_layer},
+            {"CuDNNLSTM", create_lstm_layer},
             {"GRU", create_gru_layer},
+            {"CuDNNGRU", create_gru_layer},
             {"Bidirectional", create_bidirectional_layer},
             {"TimeDistributed", create_time_distributed_layer},
             {"Softmax", create_softmax_layer},

--- a/include/fdeep/layers/bidirectional_layer.hpp
+++ b/include/fdeep/layers/bidirectional_layer.hpp
@@ -73,7 +73,7 @@ protected:
         
         const tensor5 input_reversed = reverse_time_series_in_tensor5(input);
         
-        if (wrapped_layer_type_ == "LSTM")
+        if (wrapped_layer_type_ == "LSTM" || wrapped_layer_type_ == "CuDNNLSTM")
         {
             result_forward = lstm_impl(input, n_units_, use_bias_, return_sequences_,
                                        forward_weights_, forward_recurrent_weights_,
@@ -82,7 +82,7 @@ protected:
                                         backward_weights_, backward_recurrent_weights_,
                                         bias_backward_, activation_, recurrent_activation_);
         }
-        else if (wrapped_layer_type_ == "GRU")
+        else if (wrapped_layer_type_ == "GRU" || wrapped_layer_type_ == "CuDNNGRU")
         {
             result_forward = gru_impl(input, n_units_, use_bias_, reset_after_, return_sequences_,
                                       forward_weights_, forward_recurrent_weights_,

--- a/include/fdeep/tensor5.hpp
+++ b/include/fdeep/tensor5.hpp
@@ -728,13 +728,34 @@ inline tensor5 max_tensor5s(const tensor5s& ts)
     return tensor5(ts.front().shape(), std::move(result_values));
 }
 
+inline ColMajorMatrixXf eigen_col_major_mat_from_values(std::size_t height,
+    std::size_t width, const float_type* values)
+{
+    ColMajorMatrixXf m(height, width);
+    std::memcpy(m.data(), values, height * width * sizeof(float_type));
+    return m;
+}
+
+inline ColMajorMatrixXf eigen_col_major_mat_from_values(std::size_t height,
+    std::size_t width, const float_vec& values)
+{
+    assertion(height * width == values.size(), "invalid shape");
+    return eigen_col_major_mat_from_values(height, width, values.data());
+}
+
+inline RowMajorMatrixXf eigen_row_major_mat_from_values(std::size_t height,
+    std::size_t width, const float_type* values)
+{
+    RowMajorMatrixXf m(height, width);
+    std::memcpy(m.data(), values, height * width * sizeof(float_type));
+    return m;
+}
+
 inline RowMajorMatrixXf eigen_row_major_mat_from_values(std::size_t height,
     std::size_t width, const float_vec& values)
 {
     assertion(height * width == values.size(), "invalid shape");
-    RowMajorMatrixXf m(height, width);
-    std::memcpy(m.data(), values.data(), values.size() * sizeof(float_type));
-    return m;
+    return eigen_row_major_mat_from_values(height, width, values.data());
 }
 
 inline shared_float_vec eigen_row_major_mat_to_values(const RowMajorMatrixXf& m)

--- a/include/fdeep/tensor5.hpp
+++ b/include/fdeep/tensor5.hpp
@@ -728,34 +728,13 @@ inline tensor5 max_tensor5s(const tensor5s& ts)
     return tensor5(ts.front().shape(), std::move(result_values));
 }
 
-inline ColMajorMatrixXf eigen_col_major_mat_from_values(std::size_t height,
-    std::size_t width, const float_type* values)
-{
-    ColMajorMatrixXf m(height, width);
-    std::memcpy(m.data(), values, height * width * sizeof(float_type));
-    return m;
-}
-
-inline ColMajorMatrixXf eigen_col_major_mat_from_values(std::size_t height,
+inline RowMajorMatrixXf eigen_row_major_mat_from_values(std::size_t height,
     std::size_t width, const float_vec& values)
 {
     assertion(height * width == values.size(), "invalid shape");
-    return eigen_col_major_mat_from_values(height, width, values.data());
-}
-
-inline RowMajorMatrixXf eigen_row_major_mat_from_values(std::size_t height,
-    std::size_t width, const float_type* values)
-{
     RowMajorMatrixXf m(height, width);
-    std::memcpy(m.data(), values, height * width * sizeof(float_type));
+    std::memcpy(m.data(), values.data(), values.size() * sizeof(float_type));
     return m;
-}
-
-inline RowMajorMatrixXf eigen_row_major_mat_from_values(std::size_t height,
-    std::size_t width, const float_vec& values)
-{
-    assertion(height * width == values.size(), "invalid shape");
-    return eigen_row_major_mat_from_values(height, width, values.data());
 }
 
 inline shared_float_vec eigen_row_major_mat_to_values(const RowMajorMatrixXf& m)

--- a/keras_export/convert_model.py
+++ b/keras_export/convert_model.py
@@ -348,6 +348,18 @@ def show_gru_layer(layer):
     return result
 
 
+def show_cudnn_gru_layer(layer):
+    """Serialize a GPU-trained GRU layer to dict"""
+    weights = layer.get_weights()
+    assert len(weights) == 3
+
+    result = {'weights': encode_floats(weights[0]),
+              'recurrent_weights': encode_floats(weights[1]),
+              'bias': encode_floats(weights[2])}
+
+    return result
+
+
 def show_bidirectional_layer(layer):
     """Serialize Bidirectional layer to dict"""
     forward_weights = layer.forward_layer.get_weights()
@@ -381,6 +393,7 @@ def get_layer_functions_dict():
         'Embedding': show_embedding_layer,
         'LSTM': show_lstm_layer,
         'GRU': show_gru_layer,
+        'CuDNNGRU': show_cudnn_gru_layer,
         'Bidirectional': show_bidirectional_layer,
         'TimeDistributed': show_time_distributed_layer,
         'UpSampling2D': check_upsampling_2d_layer

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,10 @@ add_custom_command ( OUTPUT test_model_recurrent.h5
                      COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/generate_test_models.py recurrent test_model_recurrent.h5"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
 
+add_custom_command ( OUTPUT test_model_gru.h5
+                     COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/generate_test_models.py gru test_model_gru.h5"
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
+
 add_custom_command ( OUTPUT test_model_variable.h5
                      COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/generate_test_models.py variable test_model_variable.h5"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
@@ -56,6 +60,11 @@ add_custom_command ( OUTPUT test_model_embedding.json
 add_custom_command ( OUTPUT test_model_recurrent.json
                      DEPENDS test_model_recurrent.h5
                      COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/convert_model.py test_model_recurrent.h5 test_model_recurrent.json"
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
+
+add_custom_command ( OUTPUT test_model_gru.json
+                     DEPENDS test_model_gru.h5
+                     COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/convert_model.py test_model_gru.h5 test_model_gru.json"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
 
 add_custom_command ( OUTPUT test_model_variable.json
@@ -95,6 +104,7 @@ _add_test(test_model_small_test test_model_small.json)
 _add_test(test_model_pooling_test test_model_pooling.json)
 _add_test(test_model_embedding_test test_model_embedding.json)
 _add_test(test_model_recurrent_test test_model_recurrent.json)
+_add_test(test_model_gru_test test_model_gru.json)
 _add_test(test_model_variable_test test_model_variable.json)
 _add_test(test_model_sequential_test test_model_sequential.json)
 if(FDEEP_BUILD_FULL_TEST)
@@ -109,6 +119,7 @@ if(FDEEP_BUILD_FULL_TEST)
     COMMAND test_model_pooling_test
     COMMAND test_model_embedding_test
     COMMAND test_model_recurrent_test
+    COMMAND test_model_gru_test
     COMMAND test_model_variable_test
     COMMAND test_model_sequential_test
     COMMAND test_model_full_test
@@ -124,6 +135,7 @@ else()
     COMMAND test_model_pooling_test
     COMMAND test_model_embedding_test
     COMMAND test_model_recurrent_test
+    COMMAND test_model_gru_test
     COMMAND test_model_variable_test
     COMMAND test_model_sequential_test
     COMMAND readme_example_main

--- a/test/applications_performance.cpp
+++ b/test/applications_performance.cpp
@@ -13,6 +13,7 @@ int main()
         "test_model_variable.json",
         "test_model_sequential.json",
         "test_model_recurrent.json",
+        "test_model_gru.json",
         "test_model_full.json",
         "densenet121.json",
         "densenet169.json",

--- a/test/test_model_gru_test.cpp
+++ b/test/test_model_gru_test.cpp
@@ -1,0 +1,23 @@
+// Copyright 2016, Tobias Hermann.
+// https://github.com/Dobiasd/frugally-deep
+// Distributed under the MIT License.
+// (See accompanying LICENSE file or at
+//  https://opensource.org/licenses/MIT)
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest/doctest.h"
+#include <fdeep/fdeep.hpp>
+
+#define FDEEP_FLOAT_TYPE double
+
+TEST_CASE("test_model_gru_test, load_model")
+{
+    const auto model = fdeep::load_model("../test_model_gru.json",
+        true, fdeep::cout_logger, static_cast<fdeep::float_type>(0.00001));
+    const auto multi_inputs = fplus::generate<std::vector<fdeep::tensor5s>>(
+        [&]() -> fdeep::tensor5s {return model.generate_dummy_inputs();},
+        10);
+
+    model.predict_multi(multi_inputs, false);
+    model.predict_multi(multi_inputs, true);
+}


### PR DESCRIPTION
This pull request ports Keras' ability to import CuDNNGRU layer weights into frugally-deep. CuDNNGRU input and recurrent kernel matrices have a different internal layout than corresponding GRU matrices. When importing weights from a model trained on a GPU with CuDNN into a CPU-only model architecture that uses the plain GRU layer, Keras does the necessary conversions. However, the exact same conversions are required when a `*.hdf5` model is cross-compiled to a frugally-deep `*.json` model with `convert_model.py`.