### PR TITLE
Allow weights trained with CuDNNLSTM to be used without GPU 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Layer types typically used in image recognition/generation are supported, making
 
 * `Add`, `Concatenate`, `Subtract`, `Multiply`, `Average`, `Maximum`
 * `AveragePooling1D/2D`, `GlobalAveragePooling1D/2D`
-* `Bidirectional`, `TimeDistributed`, `GRU`, `LSTM`, `CuDNNGRU`
+* `Bidirectional`, `TimeDistributed`, `GRU`, `LSTM`, `CuDNNGRU`, `CuDNNLSTM`
 * `Conv1D/2D`, `SeparableConv2D`, `DepthwiseConv2D`
 * `Cropping1D/2D`, `ZeroPadding1D/2D`
 * `BatchNormalization`, `Dense`, `Flatten`
@@ -75,7 +75,6 @@ Layer types typically used in image recognition/generation are supported, making
 `Conv2DTranspose`,
 `Conv3D`,
 `ConvLSTM2D`,
-`CuDNNLSTM`,
 `Cropping3D`,
 `Dot`,
 `GaussianNoise`,

--- a/include/fdeep/import_model.hpp
+++ b/include/fdeep/import_model.hpp
@@ -916,7 +916,12 @@ inline layer_ptr create_lstm_layer(const get_param_f &get_param,
     auto&& config = data["config"];
     const std::size_t units = config["units"];
     const std::string unit_activation = json_object_get(config, "activation", std::string("tanh"));
-    const std::string recurrent_activation = json_object_get(config, "recurrent_activation", std::string("sigmoid"));
+    const std::string recurrent_activation = json_object_get(config,
+        "recurrent_activation",
+        data["class_name"] == "CuDNNLSTM"
+            ? std::string("sigmoid")
+            : std::string("hard_sigmoid")
+    );
     const bool use_bias = json_object_get(config, "use_bias", true);
 
     float_vec bias;

--- a/include/fdeep/import_model.hpp
+++ b/include/fdeep/import_model.hpp
@@ -975,16 +975,16 @@ inline layer_ptr create_bidirectional_layer(const get_param_f& get_param,
     const std::string merge_mode = data["config"]["merge_mode"];
     auto&& layer = data["config"]["layer"];
     auto&& layer_config = layer["config"];
+    const std::string wrapped_layer_type = layer["class_name"];
     const std::size_t units = layer_config["units"];
     const std::string unit_activation = json_object_get(layer_config, "activation", std::string("tanh"));
     const std::string recurrent_activation = json_object_get(layer_config,
         "recurrent_activation",
-        layer["class_name"] == "CuDNNGRU" || layer["class_name"] == "CuDNNLSTM"
+        wrapped_layer_type == "CuDNNGRU" || wrapped_layer_type == "CuDNNLSTM"
             ? std::string("sigmoid")
             : std::string("hard_sigmoid")
     );
     const bool use_bias = json_object_get(layer_config, "use_bias", true);
-    const std::string wrapped_layer_type = data["config"]["layer"]["class_name"];
 
     float_vec forward_bias;
     float_vec backward_bias;
@@ -1003,7 +1003,7 @@ inline layer_ptr create_bidirectional_layer(const get_param_f& get_param,
 
     const bool reset_after = json_object_get(layer_config,
         "reset_after",
-        layer["class_name"] == "CuDNNGRU"
+        wrapped_layer_type == "CuDNNGRU"
     );
     const bool return_sequences = json_object_get(layer_config, "return_sequences", false);
 

--- a/keras_export/convert_model.py
+++ b/keras_export/convert_model.py
@@ -49,7 +49,6 @@ def transform_kernels(kernels, n_gates, transform_func):
     numpy.ndarray
         Transformed composite matrix of input or recurrent kernels in C-contiguous layout.
     """
-    n_gates = 3
     return np.require(np.hstack([transform_func(kernel) for kernel in np.hsplit(kernels, n_gates)]), requirements='C')
 
 def transform_bias(bias):
@@ -385,21 +384,6 @@ def transform_cudnn_weights(input_weights, recurrent_weights, n_gates):
     return transform_kernels(input_weights, n_gates, transform_input_kernel), transform_kernels(recurrent_weights, n_gates, transform_recurrent_kernel)
 
 
-def show_cudnn_gru_layer(layer):
-    """Serialize a GPU-trained GRU layer to dict"""
-    weights = layer.get_weights()
-    assert len(weights) == 3  # CuDNN GRU always has a bias
-
-    n_gates = 3
-    input_weights, recurrent_weights = transform_cudnn_weights(weights[0], weights[1], n_gates)
-
-    result = {'weights': encode_floats(input_weights),
-              'recurrent_weights': encode_floats(recurrent_weights),
-              'bias': encode_floats(weights[2])}
-
-    return result
-
-
 def show_cudnn_lstm_layer(layer):
     """Serialize a GPU-trained LSTM layer to dict"""
     weights = layer.get_weights()
@@ -411,6 +395,21 @@ def show_cudnn_lstm_layer(layer):
     result = {'weights': encode_floats(input_weights),
               'recurrent_weights': encode_floats(recurrent_weights),
               'bias': encode_floats(transform_bias(weights[2]))}
+
+    return result
+
+
+def show_cudnn_gru_layer(layer):
+    """Serialize a GPU-trained GRU layer to dict"""
+    weights = layer.get_weights()
+    assert len(weights) == 3  # CuDNN GRU always has a bias
+
+    n_gates = 3
+    input_weights, recurrent_weights = transform_cudnn_weights(weights[0], weights[1], n_gates)
+
+    result = {'weights': encode_floats(input_weights),
+              'recurrent_weights': encode_floats(recurrent_weights),
+              'bias': encode_floats(weights[2])}
 
     return result
 

--- a/keras_export/convert_model.py
+++ b/keras_export/convert_model.py
@@ -31,11 +31,30 @@ def transform_recurrent_kernel(kernel):
     """Transforms weights of a single CuDNN recurrent kernel into the regular Keras format."""
     return kernel.T
 
-def transform_kernels(kernels, transform_func):
-    """Transforms CuDNN kernel matrices (either LSTM or GRU) into the regular Keras format."""
+def transform_kernels(kernels, n_gates, transform_func):
+    """
+    Transforms CuDNN kernel matrices (either LSTM or GRU) into the regular Keras format.
+    
+    Parameters
+    ----------
+    kernels : numpy.ndarray
+        Composite matrix of input or recurrent kernels.
+    n_gates : int
+        Number of recurrent unit gates, 3 for GRU, 4 for LSTM.
+    transform_func: function(numpy.ndarray)
+        Function to apply to each input or recurrent kernel.
+
+    Returns
+    -------
+    numpy.ndarray
+        Transformed composite matrix of input or recurrent kernels in C-contiguous layout.
+    """
     n_gates = 3
     return np.require(np.hstack([transform_func(kernel) for kernel in np.hsplit(kernels, n_gates)]), requirements='C')
 
+def transform_bias(bias):
+    """Transforms bias weights of an LSTM layer into the regular Keras format."""
+    return np.sum(np.split(bias, 2, axis=0), axis=0)
 
 def write_text_file(path, text):
     """Write a string to a file"""
@@ -362,14 +381,36 @@ def show_gru_layer(layer):
     return result
 
 
+def transform_cudnn_weights(input_weights, recurrent_weights, n_gates):
+    return transform_kernels(input_weights, n_gates, transform_input_kernel), transform_kernels(recurrent_weights, n_gates, transform_recurrent_kernel)
+
+
 def show_cudnn_gru_layer(layer):
     """Serialize a GPU-trained GRU layer to dict"""
     weights = layer.get_weights()
     assert len(weights) == 3  # CuDNN GRU always has a bias
 
-    result = {'weights': encode_floats(transform_kernels(weights[0], transform_input_kernel)),
-              'recurrent_weights': encode_floats(transform_kernels(weights[1], transform_recurrent_kernel)),
+    n_gates = 3
+    input_weights, recurrent_weights = transform_cudnn_weights(weights[0], weights[1], n_gates)
+
+    result = {'weights': encode_floats(input_weights),
+              'recurrent_weights': encode_floats(recurrent_weights),
               'bias': encode_floats(weights[2])}
+
+    return result
+
+
+def show_cudnn_lstm_layer(layer):
+    """Serialize a GPU-trained LSTM layer to dict"""
+    weights = layer.get_weights()
+    assert len(weights) == 3  # CuDNN LSTM always has a bias
+
+    n_gates = 4
+    input_weights, recurrent_weights = transform_cudnn_weights(weights[0], weights[1], n_gates)
+
+    result = {'weights': encode_floats(input_weights),
+              'recurrent_weights': encode_floats(recurrent_weights),
+              'bias': encode_floats(transform_bias(weights[2]))}
 
     return result
 
@@ -377,22 +418,34 @@ def show_cudnn_gru_layer(layer):
 def get_transform_func(layer):
     """Returns functions that can be applied to layer weights to transform them into the standard Keras format, if applicable."""
     if layer.__class__.__name__ in ['CuDNNGRU', 'CuDNNLSTM']:
-        input_transform_func = lambda kernels: transform_kernels(kernels, transform_input_kernel)
-        recurrent_transform_func = lambda kernels: transform_kernels(kernels, transform_recurrent_kernel)
+        if layer.__class__.__name__ == 'CuDNNGRU':
+            n_gates = 3
+        elif layer.__class__.__name__ == 'CuDNNLSTM':
+            n_gates = 4
+
+        input_transform_func = lambda kernels: transform_kernels(kernels, n_gates, transform_input_kernel)
+        recurrent_transform_func = lambda kernels: transform_kernels(kernels, n_gates, transform_recurrent_kernel)
     else:
         input_transform_func = lambda kernels: kernels
         recurrent_transform_func = lambda kernels: kernels
-    return input_transform_func, recurrent_transform_func
+
+    if layer.__class__.__name__ == 'CuDNNLSTM':
+        bias_transform_func = transform_bias
+    else:
+        bias_transform_func = lambda bias: bias
+
+    return input_transform_func, recurrent_transform_func, bias_transform_func
+
 
 def show_bidirectional_layer(layer):
     """Serialize Bidirectional layer to dict"""
     forward_weights = layer.forward_layer.get_weights()
     assert len(forward_weights) == 2 or len(forward_weights) == 3
-    forward_input_transform_func, forward_recurrent_transform_func = get_transform_func(layer.forward_layer)
+    forward_input_transform_func, forward_recurrent_transform_func, forward_bias_transform_func = get_transform_func(layer.forward_layer)
 
     backward_weights = layer.backward_layer.get_weights()
     assert len(backward_weights) == 2 or len(backward_weights) == 3
-    backward_input_transform_func, backward_recurrent_transform_func = get_transform_func(layer.backward_layer)
+    backward_input_transform_func, backward_recurrent_transform_func, backward_bias_transform_func = get_transform_func(layer.backward_layer)
 
     result = {'forward_weights': encode_floats(forward_input_transform_func(forward_weights[0])),
               'forward_recurrent_weights': encode_floats(forward_recurrent_transform_func(forward_weights[1])),
@@ -400,9 +453,9 @@ def show_bidirectional_layer(layer):
               'backward_recurrent_weights': encode_floats(backward_recurrent_transform_func(backward_weights[1]))}
 
     if len(forward_weights) == 3:
-        result['forward_bias'] = encode_floats(forward_weights[2])
+        result['forward_bias'] = encode_floats(forward_bias_transform_func(forward_weights[2]))
     if len(backward_weights) == 3:
-        result['backward_bias'] = encode_floats(backward_weights[2])
+        result['backward_bias'] = encode_floats(backward_bias_transform_func(backward_weights[2]))
 
     return result
 
@@ -419,6 +472,7 @@ def get_layer_functions_dict():
         'Embedding': show_embedding_layer,
         'LSTM': show_lstm_layer,
         'GRU': show_gru_layer,
+        'CuDNNLSTM': show_cudnn_lstm_layer,
         'CuDNNGRU': show_cudnn_gru_layer,
         'Bidirectional': show_bidirectional_layer,
         'TimeDistributed': show_time_distributed_layer,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,10 @@ add_custom_command ( OUTPUT test_model_recurrent.h5
                      COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/generate_test_models.py recurrent test_model_recurrent.h5"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
 
+add_custom_command ( OUTPUT test_model_lstm.h5
+                     COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/generate_test_models.py lstm test_model_lstm.h5"
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
+
 add_custom_command ( OUTPUT test_model_gru.h5
                      COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/generate_test_models.py gru test_model_gru.h5"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
@@ -60,6 +64,11 @@ add_custom_command ( OUTPUT test_model_embedding.json
 add_custom_command ( OUTPUT test_model_recurrent.json
                      DEPENDS test_model_recurrent.h5
                      COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/convert_model.py test_model_recurrent.h5 test_model_recurrent.json"
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
+
+add_custom_command ( OUTPUT test_model_lstm.json
+                     DEPENDS test_model_lstm.h5
+                     COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/convert_model.py test_model_lstm.h5 test_model_lstm.json"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
 
 add_custom_command ( OUTPUT test_model_gru.json
@@ -104,6 +113,7 @@ _add_test(test_model_small_test test_model_small.json)
 _add_test(test_model_pooling_test test_model_pooling.json)
 _add_test(test_model_embedding_test test_model_embedding.json)
 _add_test(test_model_recurrent_test test_model_recurrent.json)
+_add_test(test_model_lstm_test test_model_lstm.json)
 _add_test(test_model_gru_test test_model_gru.json)
 _add_test(test_model_variable_test test_model_variable.json)
 _add_test(test_model_sequential_test test_model_sequential.json)
@@ -119,6 +129,7 @@ if(FDEEP_BUILD_FULL_TEST)
     COMMAND test_model_pooling_test
     COMMAND test_model_embedding_test
     COMMAND test_model_recurrent_test
+    COMMAND test_model_lstm_test
     COMMAND test_model_gru_test
     COMMAND test_model_variable_test
     COMMAND test_model_sequential_test
@@ -135,6 +146,7 @@ else()
     COMMAND test_model_pooling_test
     COMMAND test_model_embedding_test
     COMMAND test_model_recurrent_test
+    COMMAND test_model_lstm_test
     COMMAND test_model_gru_test
     COMMAND test_model_variable_test
     COMMAND test_model_sequential_test

--- a/test/applications_performance.cpp
+++ b/test/applications_performance.cpp
@@ -13,6 +13,7 @@ int main()
         "test_model_variable.json",
         "test_model_sequential.json",
         "test_model_recurrent.json",
+        "test_model_lstm.json",
         "test_model_gru.json",
         "test_model_full.json",
         "densenet121.json",

--- a/test/test_model_lstm_test.cpp
+++ b/test/test_model_lstm_test.cpp
@@ -1,0 +1,23 @@
+// Copyright 2016, Tobias Hermann.
+// https://github.com/Dobiasd/frugally-deep
+// Distributed under the MIT License.
+// (See accompanying LICENSE file or at
+//  https://opensource.org/licenses/MIT)
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest/doctest.h"
+#include <fdeep/fdeep.hpp>
+
+#define FDEEP_FLOAT_TYPE double
+
+TEST_CASE("test_model_lstm_test, load_model")
+{
+    const auto model = fdeep::load_model("../test_model_lstm.json",
+        true, fdeep::cout_logger, static_cast<fdeep::float_type>(0.00001));
+    const auto multi_inputs = fplus::generate<std::vector<fdeep::tensor5s>>(
+        [&]() -> fdeep::tensor5s {return model.generate_dummy_inputs();},
+        10);
+
+    model.predict_multi(multi_inputs, false);
+    model.predict_multi(multi_inputs, true);
+}


### PR DESCRIPTION
This pull request ports Keras' ability to import CuDNNLSTM layer weights into frugally-deep. CuDNNLSTM input kernel, recurrent kernel and bias matrices have a different internal layout than corresponding LSTM matrices. When importing weights from a model trained on a GPU with CuDNN into a CPU-only model architecture that uses the plain LSTM layer, Keras does the necessary conversions. However, the exact same conversions are required when a `*.hdf5` model is cross-compiled to a frugally-deep `*.json` model with `convert_model.py`.

This pull request extends upon similar changes with the addition of the CuDNNGRU layer.