### PR TITLE
Add padding option "causal" to Conv1D

### DIFF
--- a/include/fdeep/import_model.hpp
+++ b/include/fdeep/import_model.hpp
@@ -95,7 +95,7 @@ ValueT json_object_get(const nlohmann::json& data, KeyT&& key, ValueT&& default_
     if (it != data.end())
         return *it;
     else
-        return default_value;
+        return std::forward<ValueT>(default_value);
 }
 
 inline bool json_obj_has_member(const nlohmann::json& data,
@@ -337,6 +337,7 @@ inline padding create_padding(const std::string& padding_str)
         fplus::choose<std::string, padding>({
         { std::string("valid"), padding::valid },
         { std::string("same"), padding::same },
+        { std::string("causal"), padding::causal },
     }, padding_str));
 }
 

--- a/keras_export/convert_model.py
+++ b/keras_export/convert_model.py
@@ -252,7 +252,7 @@ def show_conv_1d_layer(layer):
     assert len(weights) == 1 or len(weights) == 2
     assert len(weights[0].shape) == 3
     weights_flat = prepare_filter_weights_conv_1d(weights[0])
-    assert layer.padding in ['valid', 'same']
+    assert layer.padding in ['valid', 'same', 'causal']
     assert len(layer.input_shape) == 3
     assert layer.input_shape[0] is None
     result = {

--- a/keras_export/generate_test_models.py
+++ b/keras_export/generate_test_models.py
@@ -221,6 +221,34 @@ def get_test_model_embedding():
     return model
 
 
+def get_test_model_convolutional():
+    """Returns a minimalistic test model for convolutional layers."""
+    input_shapes = [
+        (17, 4),
+        (6, 10),
+        (20, 40),
+    ]
+
+    inputs = [Input(shape=s) for s in input_shapes]
+    outputs = []
+
+    for inp in inputs:
+        for padding in ['same','valid','causal']:
+            conv = Conv1D(6, 3, padding=padding, activation='relu')(inp)
+            outputs.append(conv)
+
+    model = Model(inputs=inputs, outputs=outputs, name='test_model_convolutional')
+    model.compile(loss='mse', optimizer='nadam')
+
+    # fit to dummy data
+    training_data_size = 1
+    data_in = generate_input_data(training_data_size, input_shapes)
+    initial_data_out = model.predict(data_in)
+    data_out = generate_output_data(training_data_size, initial_data_out)
+    model.fit(data_in, data_out, epochs=10)
+    return model
+
+
 def get_test_model_recurrent():
     """Returns a minimalistic test model for recurrent layers."""
     input_shapes = [
@@ -256,7 +284,7 @@ def get_test_model_recurrent():
 
     outputs.append(lstm3)
 
-    conv1 = (Conv1D(2, 1, activation='sigmoid'))(inputs[1])
+    conv1 = Conv1D(2, 1, activation='sigmoid')(inputs[1])
     lstm4 = LSTM(units=15,
                  return_sequences=False,
                  bias_initializer='random_uniform',
@@ -596,7 +624,7 @@ def get_test_model_full():
         outputs.append(Concatenate(axis=axis)([inputs[18], inputs[19]]))
 
     for inp in inputs[6:8]:
-        for padding in ['valid', 'same']:
+        for padding in ['valid', 'same', 'causal']:
             for s in range(1, 6):
                 for out_channels in [1, 2]:
                     for d in range(1, 4):
@@ -816,6 +844,7 @@ def main():
             'small': get_test_model_small,
             'pooling': get_test_model_pooling,
             'embedding': get_test_model_embedding,
+            'convolutional': get_test_model_convolutional,
             'recurrent': get_test_model_recurrent,
             'lstm': get_test_model_lstm,
             'gru': get_test_model_gru,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,10 @@ add_custom_command ( OUTPUT test_model_embedding.h5
                      COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/generate_test_models.py embedding test_model_embedding.h5"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
 
+add_custom_command ( OUTPUT test_model_convolutional.h5
+                     COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/generate_test_models.py convolutional test_model_convolutional.h5"
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
+
 add_custom_command ( OUTPUT test_model_recurrent.h5
                      COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/generate_test_models.py recurrent test_model_recurrent.h5"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
@@ -59,6 +63,11 @@ add_custom_command ( OUTPUT test_model_pooling.json
 add_custom_command ( OUTPUT test_model_embedding.json
                      DEPENDS test_model_embedding.h5
                      COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/convert_model.py test_model_embedding.h5 test_model_embedding.json"
+                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
+
+add_custom_command ( OUTPUT test_model_convolutional.json
+                     DEPENDS test_model_convolutional.h5
+                     COMMAND bash -c "python3 ${FDEEP_TOP_DIR}/keras_export/convert_model.py test_model_convolutional.h5 test_model_convolutional.json"
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/)
 
 add_custom_command ( OUTPUT test_model_recurrent.json
@@ -112,6 +121,7 @@ endmacro()
 _add_test(test_model_small_test test_model_small.json)
 _add_test(test_model_pooling_test test_model_pooling.json)
 _add_test(test_model_embedding_test test_model_embedding.json)
+_add_test(test_model_convolutional_test test_model_convolutional.json)
 _add_test(test_model_recurrent_test test_model_recurrent.json)
 _add_test(test_model_lstm_test test_model_lstm.json)
 _add_test(test_model_gru_test test_model_gru.json)
@@ -128,6 +138,7 @@ if(FDEEP_BUILD_FULL_TEST)
     COMMAND test_model_small_test
     COMMAND test_model_pooling_test
     COMMAND test_model_embedding_test
+    COMMAND test_model_convolutional_test
     COMMAND test_model_recurrent_test
     COMMAND test_model_lstm_test
     COMMAND test_model_gru_test
@@ -145,6 +156,7 @@ else()
     COMMAND test_model_small_test
     COMMAND test_model_pooling_test
     COMMAND test_model_embedding_test
+    COMMAND test_model_convolutional_test
     COMMAND test_model_recurrent_test
     COMMAND test_model_lstm_test
     COMMAND test_model_gru_test

--- a/test/test_model_convolutional_test.cpp
+++ b/test/test_model_convolutional_test.cpp
@@ -1,0 +1,23 @@
+// Copyright 2016, Tobias Hermann.
+// https://github.com/Dobiasd/frugally-deep
+// Distributed under the MIT License.
+// (See accompanying LICENSE file or at
+//  https://opensource.org/licenses/MIT)
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest/doctest.h"
+#include <fdeep/fdeep.hpp>
+
+#define FDEEP_FLOAT_TYPE double
+
+TEST_CASE("test_model_convolutional_test, load_model")
+{
+    const auto model = fdeep::load_model("../test_model_convolutional.json",
+        true, fdeep::cout_logger, static_cast<fdeep::float_type>(0.00001));
+    const auto multi_inputs = fplus::generate<std::vector<fdeep::tensor5s>>(
+        [&]() -> fdeep::tensor5s {return model.generate_dummy_inputs();},
+        10);
+
+    model.predict_multi(multi_inputs, false);
+    model.predict_multi(multi_inputs, true);
+}


### PR DESCRIPTION
This pull request introduces the padding option _causal_ to `Conv1D` layers. (Other convolutional layers do not have support for _causal_ in Keras.) _causal_ convolution produces the same output shape as padding option _same_ but behaves mostly like padding option _valid_, except for prefixing a zero left padding, which ensures outputs do not depend on future inputs.