### PR TITLE
Fix zero variance in a Normalization layer

### DIFF
--- a/include/fdeep/layers/normalization_layer.hpp
+++ b/include/fdeep/layers/normalization_layer.hpp
@@ -41,7 +41,7 @@ protected:
         const auto transform_slice = [&](const std::size_t idx, const tensor& slice) -> tensor
         {
             const auto sqrt_of_variance = std::sqrt(variance_[idx]);
-            return transform_tensor([&](float_type x){ return (x - mean_[idx]) / sqrt_of_variance; }, slice);
+            return transform_tensor([&](float_type x){ return (x - mean_[idx]) / std::fmax(sqrt_of_variance, 1e-7); }, slice);
         };
 
         if (axes_.empty()) {


### PR DESCRIPTION
If one or more of the variance values in a Normalization layer is zero, for example if the classifier was trained on images that always have a black pixel in the top-left corner, a division by zero will cause all model responses to be NaN. Keras handles this by replacing zero values with an epsilon value that defaults to 1e-7. This library should do the same - preferably with a parametric epsilon but at least with the same epsilon as Keras.