### PR TITLE
Improve the install of cmake files

### DIFF
--- a/cmake/pkgconfig.cmake
+++ b/cmake/pkgconfig.cmake
@@ -1,10 +1,13 @@
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
 # Installation (https://github.com/forexample/package-example) {
 
 # Layout. This works for all platforms:
 #   * <prefix>/lib/cmake/<PROJECT-NAME>
 #   * <prefix>/lib/
 #   * <prefix>/include/
-set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 set(include_install_dir "include")
 
 set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")


### PR DESCRIPTION
On Fedora the proper install location of cmake files depends on the arch.  For example for x86_64, this is /usr/lib64, not /usr/lib.

Copy bits from FunctionalPlus' install-rules.cmake to generalize the cmake install location.