### PR TITLE
Update minimum CMake to v3.10 and HunterGate.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10...4.0)
 
 set(FDEEP_TOP_DIR ${CMAKE_CURRENT_LIST_DIR})
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,7 +85,7 @@ The basic idea is to use the standard hunter setup but to add a git submodule to
 Your CMakeLists.txt should look something like
 
 ```cmake
-cmake_minimum_required(VERSION 3.0) # minimum requirement for Hunter
+cmake_minimum_required(VERSION 3.10...4.0) # minimum requirement for Hunter
 
 include("cmake/HunterGate.cmake") # teach your project about Hunter (before project())
 HunterGate( # Latest release shown here: https://github.com/ruslo/hunter/releases

--- a/cmake/HunterGate.cmake
+++ b/cmake/HunterGate.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2017, Ruslan Baratov
+# Copyright (c) 2013-2019, Ruslan Baratov
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -25,7 +25,7 @@
 # This is a gate file to Hunter package manager.
 # Include this file using `include` command and add package you need, example:
 #
-#     cmake_minimum_required(VERSION 3.0)
+#     cmake_minimum_required(VERSION 3.10)
 #
 #     include("cmake/HunterGate.cmake")
 #     HunterGate(
@@ -39,14 +39,18 @@
 #     hunter_add_package(Boo COMPONENTS Bar Baz)
 #
 # Projects:
-#     * https://github.com/hunter-packages/gate/
-#     * https://github.com/ruslo/hunter
+#     * https://github.com/cpp-pm/gate/
+#     * https://github.com/cpp-pm/hunter
 
 option(HUNTER_ENABLED "Enable Hunter package manager support" ON)
+
 if(HUNTER_ENABLED)
-  if(CMAKE_VERSION VERSION_LESS "3.0")
-    message(FATAL_ERROR "At least CMake version 3.0 required for hunter dependency management."
-      " Update CMake or set HUNTER_ENABLED to OFF.")
+  if(CMAKE_VERSION VERSION_LESS "3.10")
+    message(
+        FATAL_ERROR
+        "At least CMake version 3.10 required for Hunter dependency management."
+        " Update CMake or set HUNTER_ENABLED to OFF."
+    )
   endif()
 endif()
 
@@ -55,29 +59,30 @@ include(CMakeParseArguments) # cmake_parse_arguments
 option(HUNTER_STATUS_PRINT "Print working status" ON)
 option(HUNTER_STATUS_DEBUG "Print a lot info" OFF)
 option(HUNTER_TLS_VERIFY "Enable/disable TLS certificate checking on downloads" ON)
+set(HUNTER_ROOT "" CACHE FILEPATH "Override the HUNTER_ROOT.")
 
-set(HUNTER_WIKI "https://github.com/ruslo/hunter/wiki")
+set(HUNTER_ERROR_PAGE "https://hunter.readthedocs.io/en/latest/reference/errors")
 
 function(hunter_gate_status_print)
-  foreach(print_message ${ARGV})
-    if(HUNTER_STATUS_PRINT OR HUNTER_STATUS_DEBUG)
+  if(HUNTER_STATUS_PRINT OR HUNTER_STATUS_DEBUG)
+    foreach(print_message ${ARGV})
       message(STATUS "[hunter] ${print_message}")
-    endif()
-  endforeach()
+    endforeach()
+  endif()
 endfunction()
 
 function(hunter_gate_status_debug)
-  foreach(print_message ${ARGV})
-    if(HUNTER_STATUS_DEBUG)
+  if(HUNTER_STATUS_DEBUG)
+    foreach(print_message ${ARGV})
       string(TIMESTAMP timestamp)
       message(STATUS "[hunter *** DEBUG *** ${timestamp}] ${print_message}")
-    endif()
-  endforeach()
+    endforeach()
+  endif()
 endfunction()
 
-function(hunter_gate_wiki wiki_page)
-  message("------------------------------ WIKI -------------------------------")
-  message("    ${HUNTER_WIKI}/${wiki_page}")
+function(hunter_gate_error_page error_page)
+  message("------------------------------ ERROR ------------------------------")
+  message("    ${HUNTER_ERROR_PAGE}/${error_page}.html")
   message("-------------------------------------------------------------------")
   message("")
   message(FATAL_ERROR "")
@@ -90,14 +95,13 @@ function(hunter_gate_internal_error)
   endforeach()
   message("[hunter ** INTERNAL **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
   message("")
-  hunter_gate_wiki("error.internal")
+  hunter_gate_error_page("error.internal")
 endfunction()
 
 function(hunter_gate_fatal_error)
-  cmake_parse_arguments(hunter "" "WIKI" "" "${ARGV}")
-  string(COMPARE EQUAL "${hunter_WIKI}" "" have_no_wiki)
-  if(have_no_wiki)
-    hunter_gate_internal_error("Expected wiki")
+  cmake_parse_arguments(hunter "" "ERROR_PAGE" "" "${ARGV}")
+  if("${hunter_ERROR_PAGE}" STREQUAL "")
+    hunter_gate_internal_error("Expected ERROR_PAGE")
   endif()
   message("")
   foreach(x ${hunter_UNPARSED_ARGUMENTS})
@@ -105,11 +109,11 @@ function(hunter_gate_fatal_error)
   endforeach()
   message("[hunter ** FATAL ERROR **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
   message("")
-  hunter_gate_wiki("${hunter_WIKI}")
+  hunter_gate_error_page("${hunter_ERROR_PAGE}")
 endfunction()
 
 function(hunter_gate_user_error)
-  hunter_gate_fatal_error(${ARGV} WIKI "error.incorrect.input.data")
+  hunter_gate_fatal_error(${ARGV} ERROR_PAGE "error.incorrect.input.data")
 endfunction()
 
 function(hunter_gate_self root version sha1 result)
@@ -145,24 +149,21 @@ endfunction()
 # Set HUNTER_GATE_ROOT cmake variable to suitable value.
 function(hunter_gate_detect_root)
   # Check CMake variable
-  string(COMPARE NOTEQUAL "${HUNTER_ROOT}" "" not_empty)
-  if(not_empty)
+  if(HUNTER_ROOT)
     set(HUNTER_GATE_ROOT "${HUNTER_ROOT}" PARENT_SCOPE)
     hunter_gate_status_debug("HUNTER_ROOT detected by cmake variable")
     return()
   endif()
 
   # Check environment variable
-  string(COMPARE NOTEQUAL "$ENV{HUNTER_ROOT}" "" not_empty)
-  if(not_empty)
+  if(DEFINED ENV{HUNTER_ROOT})
     set(HUNTER_GATE_ROOT "$ENV{HUNTER_ROOT}" PARENT_SCOPE)
     hunter_gate_status_debug("HUNTER_ROOT detected by environment variable")
     return()
   endif()
 
   # Check HOME environment variable
-  string(COMPARE NOTEQUAL "$ENV{HOME}" "" result)
-  if(result)
+  if(DEFINED ENV{HOME})
     set(HUNTER_GATE_ROOT "$ENV{HOME}/.hunter" PARENT_SCOPE)
     hunter_gate_status_debug("HUNTER_ROOT set using HOME environment variable")
     return()
@@ -170,8 +171,7 @@ function(hunter_gate_detect_root)
 
   # Check SYSTEMDRIVE and USERPROFILE environment variable (windows only)
   if(WIN32)
-    string(COMPARE NOTEQUAL "$ENV{SYSTEMDRIVE}" "" result)
-    if(result)
+    if(DEFINED ENV{SYSTEMDRIVE})
       set(HUNTER_GATE_ROOT "$ENV{SYSTEMDRIVE}/.hunter" PARENT_SCOPE)
       hunter_gate_status_debug(
           "HUNTER_ROOT set using SYSTEMDRIVE environment variable"
@@ -179,8 +179,7 @@ function(hunter_gate_detect_root)
       return()
     endif()
 
-    string(COMPARE NOTEQUAL "$ENV{USERPROFILE}" "" result)
-    if(result)
+    if(DEFINED ENV{USERPROFILE})
       set(HUNTER_GATE_ROOT "$ENV{USERPROFILE}/.hunter" PARENT_SCOPE)
       hunter_gate_status_debug(
           "HUNTER_ROOT set using USERPROFILE environment variable"
@@ -191,23 +190,9 @@ function(hunter_gate_detect_root)
 
   hunter_gate_fatal_error(
       "Can't detect HUNTER_ROOT"
-      WIKI "error.detect.hunter.root"
+      ERROR_PAGE "error.detect.hunter.root"
   )
 endfunction()
-
-macro(hunter_gate_lock dir)
-  if(NOT HUNTER_SKIP_LOCK)
-    if("${CMAKE_VERSION}" VERSION_LESS "3.2")
-      hunter_gate_fatal_error(
-          "Can't lock, upgrade to CMake 3.2 or use HUNTER_SKIP_LOCK"
-          WIKI "error.can.not.lock"
-      )
-    endif()
-    hunter_gate_status_debug("Locking directory: ${dir}")
-    file(LOCK "${dir}" DIRECTORY GUARD FUNCTION)
-    hunter_gate_status_debug("Lock done")
-  endif()
-endmacro()
 
 function(hunter_gate_download dir)
   string(
@@ -224,7 +209,7 @@ function(hunter_gate_download dir)
         "Settings:"
         "  HUNTER_ROOT: ${HUNTER_GATE_ROOT}"
         "  HUNTER_SHA1: ${HUNTER_GATE_SHA1}"
-        WIKI "error.run.install"
+        ERROR_PAGE "error.run.install"
     )
   endif()
   string(COMPARE EQUAL "${dir}" "" is_bad)
@@ -248,7 +233,10 @@ function(hunter_gate_download dir)
   set(build_dir "${dir}/Build")
   set(cmakelists "${dir}/CMakeLists.txt")
 
-  hunter_gate_lock("${dir}")
+  hunter_gate_status_debug("Locking directory: ${dir}")
+  file(LOCK "${dir}" DIRECTORY GUARD FUNCTION)
+  hunter_gate_status_debug("Lock done")
+
   if(EXISTS "${done_location}")
     # while waiting for lock other instance can do all the job
     hunter_gate_status_debug("File '${done_location}' found, skip install")
@@ -265,7 +253,13 @@ function(hunter_gate_download dir)
   file(
       WRITE
       "${cmakelists}"
-      "cmake_minimum_required(VERSION 3.0)\n"
+      "cmake_minimum_required(VERSION 3.10)\n"
+      "if(POLICY CMP0114)\n"
+      "  cmake_policy(SET CMP0114 NEW)\n"
+      "endif()\n"
+      "if(POLICY CMP0135)\n"
+      "  cmake_policy(SET CMP0135 NEW)\n"
+      "endif()\n"
       "project(HunterDownload LANGUAGES NONE)\n"
       "include(ExternalProject)\n"
       "ExternalProject_Add(\n"
@@ -330,7 +324,11 @@ function(hunter_gate_download dir)
   )
 
   if(NOT download_result EQUAL 0)
-    hunter_gate_internal_error("Configure project failed")
+    hunter_gate_internal_error(
+        "Configure project failed."
+        "To reproduce the error run: ${CMAKE_COMMAND} -H${dir} -B${build_dir} -G${CMAKE_GENERATOR} ${toolchain_arg} ${make_arg}"
+        "In directory ${dir}"
+    )
   endif()
 
   hunter_gate_status_print(
@@ -396,14 +394,14 @@ macro(HunterGate)
     )
     include("${_hunter_self}/cmake/Hunter")
   else()
-    set(HUNTER_GATE_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
+    set(HUNTER_GATE_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}")
 
     string(COMPARE NOTEQUAL "${PROJECT_NAME}" "" _have_project_name)
     if(_have_project_name)
       hunter_gate_fatal_error(
           "Please set HunterGate *before* 'project' command. "
           "Detected project: ${PROJECT_NAME}"
-          WIKI "error.huntergate.before.project"
+          ERROR_PAGE "error.huntergate.before.project"
       )
     endif()
 
@@ -473,7 +471,7 @@ macro(HunterGate)
             "HUNTER_ROOT (${HUNTER_GATE_ROOT}) contains spaces."
             "Set HUNTER_ALLOW_SPACES_IN_PATH=ON to skip this error"
             "(Use at your own risk!)"
-            WIKI "error.spaces.in.hunter.root"
+            ERROR_PAGE "error.spaces.in.hunter.root"
         )
       endif()
     endif()
@@ -521,7 +519,9 @@ macro(HunterGate)
         hunter_gate_internal_error("${_sha1_location} not found")
       endif()
       file(READ "${_sha1_location}" _sha1_value)
-      string(COMPARE EQUAL "${_sha1_value}" "${HUNTER_GATE_SHA1}" _is_equal)
+      string(TOLOWER "${_sha1_value}" _sha1_value_lower)
+      string(TOLOWER "${HUNTER_GATE_SHA1}" _HUNTER_GATE_SHA1_lower)
+      string(COMPARE EQUAL "${_sha1_value_lower}" "${_HUNTER_GATE_SHA1_lower}" _is_equal)
       if(NOT _is_equal)
         hunter_gate_internal_error(
             "Short SHA1 collision:"


### PR DESCRIPTION
Starting from CMake 4.0, any project that does not explicitly declare compatibility with version 3.5 or newer fail hards.

As HunterGate.cmake also refers to old CMake 3.0, so new version was imported from https://github.com/cpp-pm/gate/blob/master/cmake/HunterGate.cmake

As new HunterGate.cmake requires CMake>=3.10, `cmake_minimum_required` is now set to `3.10...4.0`.

Closes #448