### PR TITLE
Bump version to 0.19.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ list(APPEND CMAKE_MODULE_PATH "${FDEEP_TOP_DIR}/cmake")
 
 include(cmake/hunter.cmake) # default off
 
-project(frugally-deep VERSION 0.18.2)
+project(frugally-deep VERSION 0.19.0)
 
 message(STATUS "===( ${PROJECT_NAME} ${PROJECT_VERSION} )===")
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,7 +63,7 @@ Just add a *conanfile.txt* with frugally-deep as a requirement and chose the gen
 
 ```
 [requires]
-frugally-deep/v0.18.2@dobiasd/stable
+frugally-deep/v0.19.0@dobiasd/stable
 
 [generators]
 cmake


### PR DESCRIPTION
## Summary

Version bump to `0.19.0` to release the new 3D layers.

Updates `CMakeLists.txt:9` and the Conan example in `INSTALL.md:66`.

## Suggested release notes

- Added support for `Conv3D`, `Conv3DTranspose`, and `UpSampling3D`
- Improved performance of element-wise tensor operations
- Fixed `transform_tensor` for non-default allocator `float_vec`

🤖 Generated with [Claude Code](https://claude.com/claude-code)