### PR TITLE
Bump tested versions to TensorFlow 2.21.0 / Keras 3.14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           # system libs
           sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev gfortran
           # python libs
-          sudo pip3 install --break-system-packages numpy scipy h5py "tensorflow==2.21.0" "keras==3.14.0"
+          sudo pip3 install --break-system-packages --ignore-installed numpy scipy h5py "tensorflow==2.21.0" "keras==3.14.0"
           echo "Python version:"
           python3 --version
           echo "Version numbers of TensorFlow and Keras:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
           sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev gfortran
           # python libs
           sudo pip3 install --upgrade pip
-          sudo pip3 install numpy scipy h5py "tensorflow==2.18.0" "keras==3.8.0"
+          sudo pip3 install numpy scipy h5py "tensorflow==2.21.0" "keras==3.14.0"
           echo "Python version:"
           python3 --version
           echo "Version numbers of TensorFlow and Keras:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
           # system libs
           sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev gfortran
           # python libs
-          sudo pip3 install --break-system-packages --upgrade pip
           sudo pip3 install --break-system-packages numpy scipy h5py "tensorflow==2.21.0" "keras==3.14.0"
           echo "Python version:"
           python3 --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [workflow_dispatch, push, pull_request]
 
 jobs:
   build_gcc:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@main
       - name: Setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
           # system libs
           sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev gfortran
           # python libs
-          sudo pip3 install --upgrade pip
-          sudo pip3 install numpy scipy h5py "tensorflow==2.21.0" "keras==3.14.0"
+          sudo pip3 install --break-system-packages --upgrade pip
+          sudo pip3 install --break-system-packages numpy scipy h5py "tensorflow==2.21.0" "keras==3.14.0"
           echo "Python version:"
           python3 --version
           echo "Version numbers of TensorFlow and Keras:"

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Requirements and Installation
 
 - A **C++14**-compatible compiler: Compilers from these versions on are fine: GCC 4.9, Clang 3.7 (libc++ 3.7) and Visual C++ 2015
 - Python 3.9 or higher
-- TensorFlow 2.18.0
-- Keras 3.8.0
+- TensorFlow 2.21.0
+- Keras 3.14.0
 
 (These are the tested versions, but somewhat older ones might work too.)
 

--- a/include/fdeep/import_model.hpp
+++ b/include/fdeep/import_model.hpp
@@ -1037,8 +1037,14 @@ namespace internal {
         const get_param_f&, const nlohmann::json& data,
         const std::string& name)
     {
-        float_type threshold = data["config"]["threshold_value"];
-        float_type default_value = data["config"]["value"];
+        // Keras renamed these config keys: threshold_value -> threshold, value -> default_value.
+        const auto& config = data["config"];
+        float_type threshold = json_obj_has_member(config, "threshold")
+            ? static_cast<float_type>(config["threshold"])
+            : static_cast<float_type>(config["threshold_value"]);
+        float_type default_value = json_obj_has_member(config, "default_value")
+            ? static_cast<float_type>(config["default_value"])
+            : static_cast<float_type>(config["value"]);
         return std::make_shared<threshold_layer>(name, threshold, default_value);
     }
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -6,13 +6,13 @@ FROM ubuntu:24.04
 RUN apt-get update -y --fix-missing
 ENV DEBIAN_FRONTEND=noninteractive
 RUN TZ=Etc/UTC apt-get -y install tzdata
-RUN apt-get install -y build-essential apt-utils cmake python3 python3-pip git llvm-17 clang-17 apt-transport-https curl gnupg patchelf
+RUN apt-get install -y build-essential apt-utils cmake python3 python3-pip git llvm-17 clang-17 apt-transport-https curl gnupg patchelf xxd
 
 RUN curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >bazel-archive-keyring.gpg
 RUN mv bazel-archive-keyring.gpg /usr/share/keyrings
 RUN echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
-RUN apt-get update -y && apt-get install -y bazel-6.5.0
-RUN ln -s /usr/bin/bazel-6.5.0 /usr/bin/bazel
+RUN apt-get update -y && apt-get install -y bazel-7.7.0
+RUN ln -s /usr/bin/bazel-7.7.0 /usr/bin/bazel
 
 RUN git clone -b 'v2.21.0' --single-branch --depth 1 https://github.com/tensorflow/tensorflow.git
 WORKDIR /tensorflow

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -14,11 +14,12 @@ RUN echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gp
 RUN apt-get update -y && apt-get install -y bazel-6.5.0
 RUN ln -s /usr/bin/bazel-6.5.0 /usr/bin/bazel
 
-RUN git clone -b 'v2.18.0' --single-branch --depth 1 https://github.com/tensorflow/tensorflow.git
+RUN git clone -b 'v2.21.0' --single-branch --depth 1 https://github.com/tensorflow/tensorflow.git
 WORKDIR /tensorflow
 RUN ./configure
 RUN bazel build -c opt --copt=-march=native --jobs 16 --local_ram_resources=HOST_RAM*.3 -c opt //tensorflow/tools/pip_package:wheel --repo_env=WHEEL_NAME=tensorflow_cpu
-RUN pip install --break-system-packages bazel-bin/tensorflow/tools/pip_package/wheel_house/tensorflow_cpu-2.18.0-cp312-cp312-linux_x86_64.whl
+RUN pip install --break-system-packages bazel-bin/tensorflow/tools/pip_package/wheel_house/tensorflow_cpu-2.21.0-cp312-cp312-linux_x86_64.whl
+RUN pip install --break-system-packages "keras==3.14.0"
 WORKDIR /
 
 RUN git clone -b 'v0.2.24' --single-branch --depth 1 https://github.com/Dobiasd/FunctionalPlus && cd FunctionalPlus && mkdir -p build && cd build && cmake .. && make && make install


### PR DESCRIPTION
## Summary
- Bump CI pin from TF 2.18.0 / Keras 3.8.0 to TF 2.21.0 / Keras 3.14.0, and update the README's documented tested versions to match.
- Accept the new Threshold layer config keys Keras 3.14 emits (`threshold` and `default_value`) while still falling back to the old keys (`threshold_value` and `value`) for models exported by older Keras versions.
- Now that CI runs against a Keras version that emits the flat single-input `input_layers` form, the existing `readme_example_main` test naturally regression-tests the fix from #463.

## Test plan
- [x] `generate_test_models.py` runs cleanly for all five model variants (sequential, autoencoder, variable, embedding, exhaustive) against TF 2.21.0 / Keras 3.14.0.
- [x] `convert_model.py` round-trips each model.
- [x] All six C++ unit tests pass locally (`test_model_exhaustive_test`, `test_model_embedding_test`, `test_model_variable_test`, `test_model_autoencoder_test`, `test_model_sequential_test`, `readme_example_main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)